### PR TITLE
🐛 implement missing `getNodeText` in fixture queries

### DIFF
--- a/lib/fixture.ts
+++ b/lib/fixture.ts
@@ -2,7 +2,7 @@ import type {PlaywrightTestArgs, TestFixture} from '@playwright/test'
 
 import {getDocument, queries as unscopedQueries} from '.'
 import {queryNames} from './common'
-import type {ScopedQueries as Queries} from './typedefs'
+import type {FixtureQueries as Queries} from './typedefs'
 
 interface TestingLibraryFixtures {
   queries: Queries
@@ -21,10 +21,13 @@ const fixture: TestFixture<Queries, PlaywrightTestArgs> = async ({page}, use) =>
     }
   })
 
+  queries.getNodeText = async e => unscopedQueries.getNodeText(e)
+
   await use(queries)
 }
 
 const fixtures = {queries: fixture}
 
+export {configure} from '.'
 export {fixture, fixtures}
 export type {Queries, TestingLibraryFixtures}

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -171,7 +171,14 @@ export type BoundFunction<T> = T extends (
   : T extends (a1: any, text: infer P, options: infer Q) => infer R
   ? (text: P, options?: Q) => R
   : never
+
 export type BoundFunctions<T> = {[P in keyof T]: BoundFunction<T[P]>}
+export type BoundQueryMethods = BoundFunctions<QueryMethods>
+
+export interface FixtureQueries extends BoundFunctions<QueryMethods> {
+  getQueriesForElement(): ScopedQueries
+  getNodeText(el: Element): Promise<string>
+}
 
 export interface ScopedQueries extends BoundFunctions<QueryMethods> {
   getQueriesForElement(): ScopedQueries

--- a/test/fixture/fixture.test.ts
+++ b/test/fixture/fixture.test.ts
@@ -44,14 +44,18 @@ test.describe('lib/fixture.ts', () => {
     )
   })
 
-  test('handles page navigations', async ({queries: {getByTestId}, page}) => {
+  test('attaches `getNodeText`', async ({queries}) => {
+    const element = await queries.getByText('Hello h1')
+
+    expect(await queries.getNodeText(element)).toEqual('Hello h1')
+  })
+
+  test('handles page navigations', async ({queries: {getByText}, page}) => {
     await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
 
-    const element = await getByTestId('testid-text-input')
+    const element = await getByText('Hello h1')
 
-    expect(await page.evaluate(el => el.outerHTML, element)).toMatch(
-      `<input type="text" data-testid="testid-text-input">`,
-    )
+    expect(await element.textContent()).toEqual('Hello h1')
   })
 
   test('should handle the get* method failures', async ({queries}) => {


### PR DESCRIPTION
The `getNodeText` was missing in the `queries` provided in the Playwright Test fixture, this implements it _and_ fixes the type (`getNodeText()` → `getNodeText(el: Element)`).