### PR TITLE
📝 Fix scoping example in fixture documentation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,11 @@ module.exports = {
         'import/no-extraneous-dependencies': ['error', {devDependencies: true}],
       },
     },
+    {
+      files: ['test/fixture/**/*.+(js|ts)'],
+      rules: {
+        'jest/no-done-callback': 'off',
+      },
+    },
   ],
 }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ yarn add --dev @playwright-testing-library/test
 
 ```ts
 import {test as baseTest} from '@playwright/test'
-import {fixtures, TestingLibraryFixtures} from '@playwright-testing-library/test/fixture'
+import {fixtures, within, TestingLibraryFixtures} from '@playwright-testing-library/test/fixture'
 
 // As only fixture
 const test = baseTest.extend<TestingLibraryFixtures>(fixtures)
@@ -79,8 +79,8 @@ const {expect} = test
 test('my form', async ({queries: {getByTestId}}) => {
   const $form = await getByTestId('my-form')
 
-  // Scope queries with `getQueriesForElement`
-  const {getByLabelText} = $form.getQueriesForElement()
+  // Scope queries with `within`
+  const {getByLabelText} = within($form)
 
   const $email = await getByLabelText('Email')
 

--- a/test/fixture/fixture.test.ts
+++ b/test/fixture/fixture.test.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as playwright from '@playwright/test'
 
 import {configure, fixtures, TestingLibraryFixtures} from '../../lib/fixture'
-import {getDocument, within} from '../../lib'
+import {getDocument, within, getQueriesForElement} from '../../lib'
 
 const test = playwright.test.extend<TestingLibraryFixtures>(fixtures)
 
@@ -150,6 +150,14 @@ test.describe('lib/fixture.ts', () => {
   test('scoping queries with `within`', async ({queries: {getByTestId}}) => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const {queryByText} = within(await getByTestId('scoped'))
+
+    expect(await queryByText('Hello h1')).toBeFalsy()
+    expect(await queryByText('Hello h3')).toBeTruthy()
+  })
+
+  test('scoping queries with `getQueriesForElement`', async ({queries: {getByTestId}}) => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const {queryByText} = getQueriesForElement(await getByTestId('scoped'))
 
     expect(await queryByText('Hello h1')).toBeFalsy()
     expect(await queryByText('Hello h3')).toBeTruthy()

--- a/test/fixture/fixture.test.ts
+++ b/test/fixture/fixture.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable jest/no-done-callback */
-
 import * as path from 'path'
 import * as playwright from '@playwright/test'
 

--- a/test/fixture/fixture.test.ts
+++ b/test/fixture/fixture.test.ts
@@ -147,12 +147,9 @@ test.describe('lib/fixture.ts', () => {
     expect(await $h3.textContent()).toEqual('Hello h3')
   })
 
-  test('should work with destructuring', async ({page}) => {
-    const document = await getDocument(page)
-    const scope = await document.$('#scoped')
-
+  test('scoping queries with `within`', async ({queries: {getByTestId}}) => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const {queryByText} = within(scope)
+    const {queryByText} = within(await getByTestId('scoped'))
 
     expect(await queryByText('Hello h1')).toBeFalsy()
     expect(await queryByText('Hello h3')).toBeTruthy()

--- a/test/fixtures/page.html
+++ b/test/fixtures/page.html
@@ -9,7 +9,7 @@
     <input id="label-text-input" type="text" />
 
     <button role="button">getByRole Test</button>
-    <div id="scoped">
+    <div id="scoped" data-testid="scoped">
       <h3>Hello h3</h3>
     </div>
 


### PR DESCRIPTION
Update scoping example in fixture section with correct usage.

##### Additional
- Make scoping test case more representative of the intended usage
- Disable irrelevant ESLint rule via `overrides` instead of comment for fixture tests
