### PR TITLE
🎨 Sort imports via strict ESLint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
-  extends: require.resolve('@hover/javascript/eslint'),
+  extends: [
+    require.resolve('@hover/javascript/eslint'),
+    require.resolve('@hover/javascript/eslint/strict'),
+  ],
   ignorePatterns: ['dom-testing-library.js', 'rollup.input.js'],
   parserOptions: {
     tsconfigRootDir: __dirname,

--- a/lib/fixture.ts
+++ b/lib/fixture.ts
@@ -1,8 +1,9 @@
 import type {PlaywrightTestArgs, TestFixture} from '@playwright/test'
 
-import {getDocument, queries as unscopedQueries} from '.'
 import {queryNames} from './common'
 import type {FixtureQueries as Queries} from './typedefs'
+
+import {getDocument, queries as unscopedQueries} from '.'
 
 interface TestingLibraryFixtures {
   queries: Queries

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,11 @@
 import {readFileSync} from 'fs'
 import * as path from 'path'
+
 import {JSHandle, Page} from 'playwright'
 import waitForExpect from 'wait-for-expect'
 
-import {ElementHandle, ConfigurationOptions, Queries, ScopedQueries} from './typedefs'
 import {queryNames} from './common'
+import {ConfigurationOptions, ElementHandle, Queries, ScopedQueries} from './typedefs'
 
 const domLibraryAsString = readFileSync(
   path.join(__dirname, '../dom-testing-library.js'),

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -1,8 +1,8 @@
 import {
   Matcher,
+  ByRoleOptions as TestingLibraryByRoleOptions,
   MatcherOptions as TestingLibraryMatcherOptions,
   SelectorMatcherOptions as TestingLibrarySelectorMatcherOptions,
-  ByRoleOptions as TestingLibraryByRoleOptions,
   waitForOptions,
 } from '@testing-library/dom'
 import {ElementHandle as PlaywrightElementHandle} from 'playwright'

--- a/test/fixture/fixture.test.ts
+++ b/test/fixture/fixture.test.ts
@@ -1,8 +1,9 @@
 import * as path from 'path'
+
 import * as playwright from '@playwright/test'
 
-import {configure, fixtures, TestingLibraryFixtures} from '../../lib/fixture'
-import {getDocument, within, getQueriesForElement} from '../../lib'
+import {getDocument, getQueriesForElement, within} from '../../lib'
+import {TestingLibraryFixtures, configure, fixtures} from '../../lib/fixture'
 
 const test = playwright.test.extend<TestingLibraryFixtures>(fixtures)
 

--- a/test/standalone/index.test.ts
+++ b/test/standalone/index.test.ts
@@ -1,6 +1,8 @@
 import * as path from 'path'
+
 import * as playwright from 'playwright'
-import {getDocument, queries, getQueriesForElement, waitFor, configure} from '../../lib'
+
+import {configure, getDocument, getQueriesForElement, queries, waitFor} from '../../lib'
 
 describe('lib/index.ts', () => {
   let browser: playwright.Browser


### PR DESCRIPTION
Enable strict linting from **@hover/javascript** and run `lint --fix`.

