### PR TITLE
✨ Support timeout configuration option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
 import {readFileSync} from 'fs'
 import * as path from 'path'
 
@@ -177,12 +179,19 @@ export function configure(options: Partial<ConfigurationOptions>): void {
     return
   }
 
-  const {testIdAttribute} = options
+  const {testIdAttribute, asyncUtilTimeout} = options
 
   if (testIdAttribute) {
     delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPageInitial.replace(
       /testIdAttribute: (['|"])data-testid(['|"])/g,
       `testIdAttribute: $1${testIdAttribute}$2`,
+    )
+  }
+
+  if (asyncUtilTimeout) {
+    delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPageInitial.replace(
+      /asyncUtilTimeout: \d+/g,
+      `asyncUtilTimeout: ${asyncUtilTimeout}`,
     )
   }
 }

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -191,4 +191,5 @@ export interface Queries extends QueryMethods {
 
 export interface ConfigurationOptions {
   testIdAttribute: string
+  asyncUtilTimeout: number
 }


### PR DESCRIPTION
Add support for the `asyncUtilsTimeout` configuration option via the `configure()` API so that the timeout for **findBy*** queries can be configured globally.

Closes #460
