### PR TITLE
✨ Add support for find queries in locator fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Unique methods, not part of **@testing-library/dom**
 
 ---
 
-The **[@testing-library/dom](https://github.com/testing-library/dom-testing-library#usage)** — All **`get*`** and **`query*`** methods are supported.
+The **[@testing-library/dom](https://github.com/testing-library/dom-testing-library#usage)** — All **`get*`**, **`query*`**, and **`find*`** methods are supported.
 
 - `getQueriesForElement(handle: ElementHandle): ElementHandle & QueryUtils` - extend the input object with the query API and return it
 - `getNodeText(handle: ElementHandle): Promise<string>` - get the text content of the element

--- a/lib/fixture/index.ts
+++ b/lib/fixture/index.ts
@@ -7,6 +7,7 @@ import {
   installTestingLibraryFixture,
   queriesFixture as locatorQueriesFixture,
   options,
+  queriesFor,
   registerSelectorsFixture,
   withinFixture,
 } from './locator'
@@ -35,9 +36,11 @@ interface LocatorFixtures extends Partial<Config> {
 
 export {configure} from '..'
 
-export type {ElementHandleFixtures as TestingLibraryFixtures}
-export {elementHandleQueriesFixture as fixture}
-export {elementHandleFixtures as fixtures}
-export type {LocatorFixtures}
-export {locatorQueriesFixture}
-export {locatorFixtures}
+export type {ElementHandleFixtures as TestingLibraryFixtures, LocatorFixtures}
+export {
+  locatorFixtures,
+  locatorQueriesFixture,
+  elementHandleQueriesFixture as fixture,
+  elementHandleFixtures as fixtures,
+  queriesFor,
+}

--- a/lib/fixture/index.ts
+++ b/lib/fixture/index.ts
@@ -1,7 +1,5 @@
 import {Fixtures} from '@playwright/test'
 
-import {Config} from '../common'
-
 import type {Queries as ElementHandleQueries} from './element-handle'
 import {queriesFixture as elementHandleQueriesFixture} from './element-handle'
 import type {Queries as LocatorQueries} from './locator'
@@ -10,12 +8,15 @@ import {
   queriesFixture as locatorQueriesFixture,
   options,
   registerSelectorsFixture,
-  within,
+  withinFixture,
 } from './locator'
+import type {Config} from './types'
+import {Within} from './types'
 
 const elementHandleFixtures: Fixtures = {queries: elementHandleQueriesFixture}
 const locatorFixtures: Fixtures = {
   queries: locatorQueriesFixture,
+  within: withinFixture,
   registerSelectors: registerSelectorsFixture,
   installTestingLibrary: installTestingLibraryFixture,
   ...options,
@@ -27,6 +28,7 @@ interface ElementHandleFixtures {
 
 interface LocatorFixtures extends Partial<Config> {
   queries: LocatorQueries
+  within: Within
   registerSelectors: void
   installTestingLibrary: void
 }
@@ -38,4 +40,4 @@ export {elementHandleQueriesFixture as fixture}
 export {elementHandleFixtures as fixtures}
 export type {LocatorFixtures}
 export {locatorQueriesFixture}
-export {locatorFixtures, within}
+export {locatorFixtures}

--- a/lib/fixture/locator/helpers.ts
+++ b/lib/fixture/locator/helpers.ts
@@ -92,6 +92,20 @@ const createFindQuery =
     return locator
   }
 
+/**
+ * Given a `Page` or `Locator` instance, return an object of Testing Library
+ * query methods that return a `Locator` instance for the queried element
+ *
+ * @internal this API is not currently intended for public usage and may be
+ * removed or changed outside of semantic release versioning. If possible, you
+ * should use the `locatorFixtures` with **@playwright/test** instead.
+ * @see {@link locatorFixtures}
+ *
+ * @param pageOrLocator `Page` or `Locator` instance to use as the query root
+ * @param config Testing Library configuration to apply to queries
+ *
+ * @returns object containing scoped Testing Library query methods
+ */
 const queriesFor = (pageOrLocator: Page | Locator, config?: Partial<Config>) =>
   allQueryNames.reduce(
     (rest, query) => ({

--- a/lib/fixture/locator/helpers.ts
+++ b/lib/fixture/locator/helpers.ts
@@ -1,6 +1,7 @@
 import {promises as fs} from 'fs'
 
 import type {Locator, Page} from '@playwright/test'
+import {errors} from '@playwright/test'
 import {queries} from '@testing-library/dom'
 
 import {configureTestingLibraryScript} from '../../common'
@@ -9,8 +10,10 @@ import type {
   AllQuery,
   Config,
   FindQuery,
+  GetQuery,
   LocatorQueries as Queries,
   Query,
+  QueryQuery,
   Selector,
   SynchronousQuery,
 } from '../types'
@@ -18,8 +21,13 @@ import type {
 const allQueryNames = Object.keys(queries) as Query[]
 
 const isAllQuery = (query: Query): query is AllQuery => query.includes('All')
+
+const isFindQuery = (query: Query): query is FindQuery => query.startsWith('find')
 const isNotFindQuery = (query: Query): query is Exclude<Query, FindQuery> =>
   !query.startsWith('find')
+
+const findQueryToGetQuery = (query: FindQuery) => query.replace(/^find/, 'get') as GetQuery
+const findQueryToQueryQuery = (query: FindQuery) => query.replace(/^find/, 'query') as QueryQuery
 
 const queryToSelector = (query: SynchronousQuery) =>
   query.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase() as Selector
@@ -41,12 +49,57 @@ const buildTestingLibraryScript = async ({config}: {config: Config}) => {
 
 const synchronousQueryNames = allQueryNames.filter(isNotFindQuery)
 
-const queriesFor = (pageOrLocator: Page | Locator) =>
-  synchronousQueryNames.reduce(
+const createFindQuery =
+  (
+    pageOrLocator: Page | Locator,
+    query: FindQuery,
+    {asyncUtilTimeout, asyncUtilExpectedState}: Partial<Config> = {},
+  ) =>
+  async (...[id, options, waitForElementOptions]: Parameters<Queries[FindQuery]>) => {
+    const synchronousOptions = ([id, options] as const).filter(Boolean)
+
+    const locator = pageOrLocator.locator(
+      `${queryToSelector(findQueryToQueryQuery(query))}=${JSON.stringify(
+        synchronousOptions,
+        replacer,
+      )}`,
+    )
+
+    const {state = asyncUtilExpectedState, timeout = asyncUtilTimeout} = waitForElementOptions ?? {}
+
+    try {
+      await locator.first().waitFor({state, timeout})
+    } catch (error) {
+      // In the case of a `waitFor` timeout from Playwright, we want to
+      // surface the appropriate error from Testing Library, so run the
+      // query one more time as `get*` knowing that it will fail with the
+      // error that we want the user to see instead of the `TimeoutError`
+      if (error instanceof errors.TimeoutError) {
+        return pageOrLocator
+          .locator(
+            `${queryToSelector(findQueryToGetQuery(query))}=${JSON.stringify(
+              synchronousOptions,
+              replacer,
+            )}`,
+          )
+          .first()
+          .waitFor({state, timeout: 100})
+      }
+
+      throw error
+    }
+
+    return locator
+  }
+
+const queriesFor = (pageOrLocator: Page | Locator, config?: Partial<Config>) =>
+  allQueryNames.reduce(
     (rest, query) => ({
       ...rest,
-      [query]: (...args: Parameters<Queries[keyof Queries]>) =>
-        pageOrLocator.locator(`${queryToSelector(query)}=${JSON.stringify(args, replacer)}`),
+      [query]: isFindQuery(query)
+        ? createFindQuery(pageOrLocator, query, config)
+        : (...args: Parameters<Queries[SynchronousQuery]>) =>
+            pageOrLocator.locator(`${queryToSelector(query)}=${JSON.stringify(args, replacer)}`),
     }),
     {} as Queries,
   )

--- a/lib/fixture/locator/index.ts
+++ b/lib/fixture/locator/index.ts
@@ -6,3 +6,4 @@ export {
   withinFixture,
 } from './fixtures'
 export type {Queries} from './fixtures'
+export {queriesFor} from './helpers'

--- a/lib/fixture/locator/index.ts
+++ b/lib/fixture/locator/index.ts
@@ -3,6 +3,6 @@ export {
   options,
   queriesFixture,
   registerSelectorsFixture,
-  within,
+  withinFixture,
 } from './fixtures'
 export type {Queries} from './fixtures'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -176,6 +176,19 @@ export function wait(
 
 export const waitFor = wait
 
+/**
+ * Configuration API for legacy queries that return `ElementHandle` instances.
+ * Only `testIdAttribute` and `asyncUtilTimeout` are currently supported.
+
+ * @see {@link https://testing-library.com/docs/dom-testing-library/api-configuration}
+ *
+ * ⚠️ This API has no effect on the queries that return `Locator` instances. Use
+ * `test.use` instead to configure the `Locator` queries.
+ *
+ * @see {@link https://github.com/testing-library/playwright-testing-library/releases/tag/v4.4.0-beta.2}
+ * 
+ * @param config 
+ */
 export function configure(config: Partial<Config>): void {
   if (!config) {
     return

--- a/test/fixtures/late-page.html
+++ b/test/fixtures/late-page.html
@@ -2,6 +2,7 @@
 <html>
   <body>
     <span>Loading...</span>
+    <span id="hidden" style="visibility: hidden">Hidden</span>
     <script>
       setTimeout(() => {
         const loaded = document.createElement('span')
@@ -15,6 +16,14 @@
         const heading2 = document.createElement('h2')
         heading2.textContent = 'Hello h2'
         document.body.appendChild(heading2)
+
+        const hidden = document.getElementById('hidden')
+        hidden.style.visibility = 'visible'
+
+        const attached = document.createElement('span')
+        attached.textContent = 'Attached'
+        attached.style.visibility = 'hidden'
+        document.body.appendChild(attached)
       }, 5000)
     </script>
   </body>


### PR DESCRIPTION
- [x] Add support for `find*` queries in locator fixture
  - [x] Rename `SupportedQuery` → `SynchronousQuery`
  - [x] Include `find*` queries in `Queries` type as `(/* ... */) => Promise<Locator>`
  - [x] Implement find queries per discussion starting [here](https://github.com/testing-library/playwright-testing-library/issues/430#issuecomment-1230726081)
	- [x] Use `locator.first().waitFor()`
	- [x] Throw proper error on timeout via `get*` query
	- [x] Wire up `waitFor`'s to `asyncUtilTimeout`
	- [x] Incorporate `waitFor`'s `state` option into our options and wire it up?
  	  - [x] Test coverage
  	  - [x] Does it make any sense to support `hidden` and `detached` just because `waitFor` supports them? https://playwright.dev/docs/api/class-locator#locator-wait-for
	- [x] Convert `within` to a fixture in order to pass `asyncUtilTimeout` properly — @sebinsua is this gonna be annoying/confusing? 

> #### ~Refactors~ Merged in #489 
> - Isolate 'standard' page (no timeout) in `describe` blocks
> - Use `queries` from Testing Library to enumerate queries (instead of internal hard-coded query name array, with the intention of removing all of the legacy `ElementHandle` implementation in a future major release)
