### PR TITLE
♻️ Refactors from locator find query branch

### DIFF
--- a/lib/fixture/locator/fixtures.ts
+++ b/lib/fixture/locator/fixtures.ts
@@ -1,11 +1,19 @@
 import type {Locator, Page, PlaywrightTestArgs, TestFixture} from '@playwright/test'
 import {selectors} from '@playwright/test'
+import {queries} from '@testing-library/dom'
 
-import {queryNames as allQueryNames} from '../../common'
 import {replacer} from '../helpers'
-import type {Config, LocatorQueries as Queries, SelectorEngine, SupportedQuery} from '../types'
+import type {
+  Config,
+  LocatorQueries as Queries,
+  Query,
+  SelectorEngine,
+  SupportedQuery,
+} from '../types'
 
 import {buildTestingLibraryScript, isAllQuery, isNotFindQuery, queryToSelector} from './helpers'
+
+const allQueryNames = Object.keys(queries) as Query[]
 
 const queryNames = allQueryNames.filter(isNotFindQuery)
 const defaultConfig: Config = {testIdAttribute: 'data-testid', asyncUtilTimeout: 1000}

--- a/lib/fixture/types.ts
+++ b/lib/fixture/types.ts
@@ -45,9 +45,10 @@ export type Query = keyof Queries
 
 export type AllQuery = Extract<Query, `${string}All${string}`>
 export type FindQuery = Extract<Query, `find${string}`>
-export type SupportedQuery = Exclude<Query, FindQuery>
+export type GetQuery = Extract<Query, `get${string}`>
+export type SynchronousQuery = Exclude<Query, FindQuery>
 
-export type Selector = KebabCase<SupportedQuery>
+export type Selector = KebabCase<SynchronousQuery>
 
 export type {Config}
 export interface ConfigFn {

--- a/test/fixture/element-handles.test.ts
+++ b/test/fixture/element-handles.test.ts
@@ -10,186 +10,195 @@ const test = playwright.test.extend<TestingLibraryFixtures>(fixtures)
 const {expect} = test
 
 test.describe('lib/fixture.ts', () => {
-  test.beforeEach(async ({page}) => {
-    await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
-  })
-
-  test('should handle the query* methods', async ({queries: {queryByText}}) => {
-    const element = await queryByText('Hello h1')
-
-    expect(element).toBeTruthy()
-    expect(await element.textContent()).toEqual('Hello h1')
-  })
-
-  test('should use the new v3 methods', async ({queries: {queryByRole}}) => {
-    const element = await queryByRole('presentation')
-
-    expect(element).toBeTruthy()
-    expect(await element.textContent()).toContain('Layout table')
-  })
-
-  test('should handle regex matching', async ({queries: {queryByText}}) => {
-    const element = await queryByText(/HeLlO h(1|7)/i)
-
-    expect(element).toBeTruthy()
-    expect(await element.textContent()).toEqual('Hello h1')
-  })
-
-  test('should handle the get* methods', async ({queries: {getByTestId}, page}) => {
-    const element = await getByTestId('testid-text-input')
-
-    expect(await page.evaluate(el => el.outerHTML, element)).toMatch(
-      `<input type="text" data-testid="testid-text-input">`,
-    )
-  })
-
-  test('attaches `getNodeText`', async ({queries}) => {
-    const element = await queries.getByText('Hello h1')
-
-    expect(await queries.getNodeText(element)).toEqual('Hello h1')
-  })
-
-  test('handles page navigations', async ({queries: {getByText}, page}) => {
-    await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
-
-    const element = await getByText('Hello h1')
-
-    expect(await element.textContent()).toEqual('Hello h1')
-  })
-
-  test('should handle the get* method failures', async ({queries}) => {
-    const {getByTitle} = queries
-    // Use the scoped element so the pretty HTML snapshot is smaller
-
-    await expect(async () => getByTitle('missing')).rejects.toThrow()
-  })
-
-  test('should handle the LabelText methods', async ({queries, page}) => {
-    const {getByLabelText} = queries
-    const element = await getByLabelText('Label A')
-    /* istanbul ignore next */
-    expect(await page.evaluate(el => el.outerHTML, element)).toMatch(
-      `<input id="label-text-input" type="text">`,
-    )
-  })
-
-  test('should handle the queryAll* methods', async ({queries, page}) => {
-    const {queryAllByText} = queries
-    const elements = await queryAllByText(/Hello/)
-    expect(elements).toHaveLength(3)
-
-    const text = await Promise.all([
-      page.evaluate(el => el.textContent, elements[0]),
-      page.evaluate(el => el.textContent, elements[1]),
-      page.evaluate(el => el.textContent, elements[2]),
-    ])
-
-    expect(text).toEqual(['Hello h1', 'Hello h2', 'Hello h3'])
-  })
-
-  test('should handle the queryAll* methods with a selector', async ({queries, page}) => {
-    const {queryAllByText} = queries
-    const elements = await queryAllByText(/Hello/, {selector: 'h2'})
-    expect(elements).toHaveLength(1)
-
-    const text = await page.evaluate(el => el.textContent, elements[0])
-
-    expect(text).toEqual('Hello h2')
-  })
-
-  test('should handle the getBy* methods with a selector', async ({queries, page}) => {
-    const {getByText} = queries
-    const element = await getByText(/Hello/, {selector: 'h2'})
-
-    const text = await page.evaluate(el => el.textContent, element)
-
-    expect(text).toEqual('Hello h2')
-  })
-
-  test('should handle the getBy* methods with a regex name', async ({queries, page}) => {
-    const {getByRole} = queries
-    const element = await getByRole('button', {name: /getBy.*Test/})
-
-    const text = await page.evaluate(el => el.textContent, element)
-
-    expect(text).toEqual('getByRole Test')
-  })
-
-  test('supports `hidden` option when querying by role', async ({queries: {queryAllByRole}}) => {
-    const elements = await queryAllByRole('img')
-    const hiddenElements = await queryAllByRole('img', {hidden: true})
-
-    expect(elements).toHaveLength(1)
-    expect(hiddenElements).toHaveLength(2)
-  })
-
-  test.describe('querying by role with `level` option', () => {
-    test('retrieves the correct elements when querying all by role', async ({
-      queries: {queryAllByRole},
-    }) => {
-      const elements = await queryAllByRole('heading')
-      const levelOneElements = await queryAllByRole('heading', {level: 3})
-
-      expect(elements).toHaveLength(3)
-      expect(levelOneElements).toHaveLength(1)
+  test.describe('standard page', () => {
+    test.beforeEach(async ({page}) => {
+      await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
     })
 
-    test('does not throw when querying for a specific element', async ({queries: {getByRole}}) => {
-      await expect(getByRole('heading', {level: 3})).resolves.not.toThrow()
-    })
-  })
+    test.afterEach(async ({page}) => page.close())
 
-  test('should get text content', async ({page}) => {
-    const document = await getDocument(page)
-    const $h3 = await document.$('#scoped h3')
+    test('should handle the query* methods', async ({queries: {queryByText}}) => {
+      const element = await queryByText('Hello h1')
 
-    expect(await $h3.textContent()).toEqual('Hello h3')
-  })
-
-  test('scoping queries with `within`', async ({queries: {getByTestId}}) => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const {queryByText} = within(await getByTestId('scoped'))
-
-    expect(await queryByText('Hello h1')).toBeFalsy()
-    expect(await queryByText('Hello h3')).toBeTruthy()
-  })
-
-  test('scoping queries with `getQueriesForElement`', async ({queries: {getByTestId}}) => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const {queryByText} = getQueriesForElement(await getByTestId('scoped'))
-
-    expect(await queryByText('Hello h1')).toBeFalsy()
-    expect(await queryByText('Hello h3')).toBeTruthy()
-  })
-
-  test.describe('configuration', () => {
-    test.afterEach(() => {
-      configure({testIdAttribute: 'data-testid'}) // cleanup
+      expect(element).toBeTruthy()
+      expect(await element.textContent()).toEqual('Hello h1')
     })
 
-    test('should support custom data-testid attribute name', async ({queries}) => {
-      configure({testIdAttribute: 'data-id'})
+    test('should use the new v3 methods', async ({queries: {queryByRole}}) => {
+      const element = await queryByRole('presentation')
 
-      const element = await queries.getByTestId('second-level-header')
-
-      expect(await queries.getNodeText(element)).toEqual('Hello h2')
+      expect(element).toBeTruthy()
+      expect(await element.textContent()).toContain('Layout table')
     })
 
-    test('should support subsequent changing the data-testid attribute names', async ({
-      queries,
-    }) => {
-      configure({testIdAttribute: 'data-id'})
-      configure({testIdAttribute: 'data-new-id'})
+    test('should handle regex matching', async ({queries: {queryByText}}) => {
+      const element = await queryByText(/HeLlO h(1|7)/i)
 
-      const element = await queries.getByTestId('first-level-header')
+      expect(element).toBeTruthy()
+      expect(await element.textContent()).toEqual('Hello h1')
+    })
+
+    test('should handle the get* methods', async ({queries: {getByTestId}, page}) => {
+      const element = await getByTestId('testid-text-input')
+
+      expect(await page.evaluate(el => el.outerHTML, element)).toMatch(
+        `<input type="text" data-testid="testid-text-input">`,
+      )
+    })
+
+    test('attaches `getNodeText`', async ({queries}) => {
+      const element = await queries.getByText('Hello h1')
 
       expect(await queries.getNodeText(element)).toEqual('Hello h1')
     })
+
+    test('handles page navigations', async ({queries: {getByText}, page}) => {
+      await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
+
+      const element = await getByText('Hello h1')
+
+      expect(await element.textContent()).toEqual('Hello h1')
+    })
+
+    test('should handle the get* method failures', async ({queries}) => {
+      const {getByTitle} = queries
+      // Use the scoped element so the pretty HTML snapshot is smaller
+
+      await expect(async () => getByTitle('missing')).rejects.toThrow()
+    })
+
+    test('should handle the LabelText methods', async ({queries, page}) => {
+      const {getByLabelText} = queries
+      const element = await getByLabelText('Label A')
+      /* istanbul ignore next */
+      expect(await page.evaluate(el => el.outerHTML, element)).toMatch(
+        `<input id="label-text-input" type="text">`,
+      )
+    })
+
+    test('should handle the queryAll* methods', async ({queries, page}) => {
+      const {queryAllByText} = queries
+      const elements = await queryAllByText(/Hello/)
+      expect(elements).toHaveLength(3)
+
+      const text = await Promise.all([
+        page.evaluate(el => el.textContent, elements[0]),
+        page.evaluate(el => el.textContent, elements[1]),
+        page.evaluate(el => el.textContent, elements[2]),
+      ])
+
+      expect(text).toEqual(['Hello h1', 'Hello h2', 'Hello h3'])
+    })
+
+    test('should handle the queryAll* methods with a selector', async ({queries, page}) => {
+      const {queryAllByText} = queries
+      const elements = await queryAllByText(/Hello/, {selector: 'h2'})
+      expect(elements).toHaveLength(1)
+
+      const text = await page.evaluate(el => el.textContent, elements[0])
+
+      expect(text).toEqual('Hello h2')
+    })
+
+    test('should handle the getBy* methods with a selector', async ({queries, page}) => {
+      const {getByText} = queries
+      const element = await getByText(/Hello/, {selector: 'h2'})
+
+      const text = await page.evaluate(el => el.textContent, element)
+
+      expect(text).toEqual('Hello h2')
+    })
+
+    test('should handle the getBy* methods with a regex name', async ({queries, page}) => {
+      const {getByRole} = queries
+      const element = await getByRole('button', {name: /getBy.*Test/})
+
+      const text = await page.evaluate(el => el.textContent, element)
+
+      expect(text).toEqual('getByRole Test')
+    })
+
+    test('supports `hidden` option when querying by role', async ({queries: {queryAllByRole}}) => {
+      const elements = await queryAllByRole('img')
+      const hiddenElements = await queryAllByRole('img', {hidden: true})
+
+      expect(elements).toHaveLength(1)
+      expect(hiddenElements).toHaveLength(2)
+    })
+
+    test.describe('querying by role with `level` option', () => {
+      test('retrieves the correct elements when querying all by role', async ({
+        queries: {queryAllByRole},
+      }) => {
+        const elements = await queryAllByRole('heading')
+        const levelOneElements = await queryAllByRole('heading', {level: 3})
+
+        expect(elements).toHaveLength(3)
+        expect(levelOneElements).toHaveLength(1)
+      })
+
+      test('does not throw when querying for a specific element', async ({
+        queries: {getByRole},
+      }) => {
+        await expect(getByRole('heading', {level: 3})).resolves.not.toThrow()
+      })
+    })
+
+    test('should get text content', async ({page}) => {
+      const document = await getDocument(page)
+      const $h3 = await document.$('#scoped h3')
+
+      expect(await $h3.textContent()).toEqual('Hello h3')
+    })
+
+    test('scoping queries with `within`', async ({queries: {getByTestId}}) => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const {queryByText} = within(await getByTestId('scoped'))
+
+      expect(await queryByText('Hello h1')).toBeFalsy()
+      expect(await queryByText('Hello h3')).toBeTruthy()
+    })
+
+    test('scoping queries with `getQueriesForElement`', async ({queries: {getByTestId}}) => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const {queryByText} = getQueriesForElement(await getByTestId('scoped'))
+
+      expect(await queryByText('Hello h1')).toBeFalsy()
+      expect(await queryByText('Hello h3')).toBeTruthy()
+    })
+
+    test.describe('configuration', () => {
+      test.afterEach(() => {
+        configure({testIdAttribute: 'data-testid'}) // cleanup
+      })
+
+      test('should support custom data-testid attribute name', async ({queries}) => {
+        configure({testIdAttribute: 'data-id'})
+
+        const element = await queries.getByTestId('second-level-header')
+
+        expect(await queries.getNodeText(element)).toEqual('Hello h2')
+      })
+
+      test('should support subsequent changing the data-testid attribute names', async ({
+        queries,
+      }) => {
+        configure({testIdAttribute: 'data-id'})
+        configure({testIdAttribute: 'data-new-id'})
+
+        const element = await queries.getByTestId('first-level-header')
+
+        expect(await queries.getNodeText(element)).toEqual('Hello h1')
+      })
+    })
   })
+
   test.describe('deferred page', () => {
     test.beforeEach(async ({page}) => {
       await page.goto(`file://${path.join(__dirname, '../fixtures/late-page.html')}`)
     })
+
+    test.afterEach(async ({page}) => page.close())
 
     test('should handle the findBy* methods', async ({queries}) => {
       const {findByText} = queries

--- a/test/fixture/locators.test.ts
+++ b/test/fixture/locators.test.ts
@@ -13,156 +13,162 @@ const test = playwright.test.extend<TestingLibraryFixtures>(fixtures)
 const {expect} = test
 
 test.describe('lib/fixture.ts (locators)', () => {
-  test.beforeEach(async ({page}) => {
-    await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
-  })
+  test.describe('standard page', () => {
+    test.beforeEach(async ({page}) => {
+      await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
+    })
 
-  test('should handle the query* methods', async ({queries: {queryByText}}) => {
-    const locator = queryByText('Hello h1')
+    test.afterEach(async ({page}) => page.close())
 
-    expect(locator).toBeTruthy()
-    expect(await locator.textContent()).toEqual('Hello h1')
-  })
+    test('should handle the query* methods', async ({queries: {queryByText}}) => {
+      const locator = queryByText('Hello h1')
 
-  test('should use the new v3 methods', async ({queries: {queryByRole}}) => {
-    const locator = queryByRole('presentation')
+      expect(locator).toBeTruthy()
+      expect(await locator.textContent()).toEqual('Hello h1')
+    })
 
-    expect(locator).toBeTruthy()
-    expect(await locator.textContent()).toContain('Layout table')
-  })
+    test('should use the new v3 methods', async ({queries: {queryByRole}}) => {
+      const locator = queryByRole('presentation')
 
-  test('should handle regex matching', async ({queries: {queryByText}}) => {
-    const locator = queryByText(/HeLlO h(1|7)/i)
+      expect(locator).toBeTruthy()
+      expect(await locator.textContent()).toContain('Layout table')
+    })
 
-    expect(locator).toBeTruthy()
-    expect(await locator.textContent()).toEqual('Hello h1')
-  })
+    test('should handle regex matching', async ({queries: {queryByText}}) => {
+      const locator = queryByText(/HeLlO h(1|7)/i)
 
-  test('should handle the get* methods', async ({queries: {getByTestId}}) => {
-    const locator = getByTestId('testid-text-input')
+      expect(locator).toBeTruthy()
+      expect(await locator.textContent()).toEqual('Hello h1')
+    })
 
-    expect(await locator.evaluate(el => el.outerHTML)).toMatch(
-      `<input type="text" data-testid="testid-text-input">`,
-    )
-  })
+    test('should handle the get* methods', async ({queries: {getByTestId}}) => {
+      const locator = getByTestId('testid-text-input')
 
-  test('handles page navigations', async ({queries: {getByText}, page}) => {
-    await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
+      expect(await locator.evaluate(el => el.outerHTML)).toMatch(
+        `<input type="text" data-testid="testid-text-input">`,
+      )
+    })
 
-    const locator = getByText('Hello h1')
+    test('handles page navigations', async ({queries: {getByText}, page}) => {
+      await page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`)
 
-    expect(await locator.textContent()).toEqual('Hello h1')
-  })
+      const locator = getByText('Hello h1')
 
-  test('should handle the get* method failures', async ({queries}) => {
-    const {getByTitle} = queries
-    // Use the scoped element so the pretty HTML snapshot is smaller
+      expect(await locator.textContent()).toEqual('Hello h1')
+    })
 
-    await expect(async () => getByTitle('missing').textContent()).rejects.toThrow()
-  })
+    test('should handle the get* method failures', async ({queries}) => {
+      const {getByTitle} = queries
+      // Use the scoped element so the pretty HTML snapshot is smaller
 
-  test('should handle the LabelText methods', async ({queries}) => {
-    const {getByLabelText} = queries
-    const locator = getByLabelText('Label A')
+      await expect(async () => getByTitle('missing').textContent()).rejects.toThrow()
+    })
 
-    /* istanbul ignore next */
-    expect(await locator.evaluate(el => el.outerHTML)).toMatch(
-      `<input id="label-text-input" type="text">`,
-    )
-  })
+    test('should handle the LabelText methods', async ({queries}) => {
+      const {getByLabelText} = queries
+      const locator = getByLabelText('Label A')
 
-  test('should handle the queryAll* methods', async ({queries}) => {
-    const {queryAllByText} = queries
-    const locator = queryAllByText(/Hello/)
+      /* istanbul ignore next */
+      expect(await locator.evaluate(el => el.outerHTML)).toMatch(
+        `<input id="label-text-input" type="text">`,
+      )
+    })
 
-    expect(await locator.count()).toEqual(3)
-
-    const text = await Promise.all([
-      locator.nth(0).textContent(),
-      locator.nth(1).textContent(),
-      locator.nth(2).textContent(),
-    ])
-
-    expect(text).toEqual(['Hello h1', 'Hello h2', 'Hello h3'])
-  })
-
-  test('should handle the queryAll* methods with a selector', async ({queries}) => {
-    const {queryAllByText} = queries
-    const locator = queryAllByText(/Hello/, {selector: 'h2'})
-
-    expect(await locator.count()).toEqual(1)
-
-    expect(await locator.textContent()).toEqual('Hello h2')
-  })
-
-  test('should handle the getBy* methods with a selector', async ({queries}) => {
-    const {getByText} = queries
-    const locator = getByText(/Hello/, {selector: 'h2'})
-
-    expect(await locator.textContent()).toEqual('Hello h2')
-  })
-
-  test('should handle the getBy* methods with a regex name', async ({queries}) => {
-    const {getByRole} = queries
-    const element = getByRole('button', {name: /getBy.*Test/})
-
-    expect(await element.textContent()).toEqual('getByRole Test')
-  })
-
-  test('supports `hidden` option when querying by role', async ({queries: {queryAllByRole}}) => {
-    const elements = queryAllByRole('img')
-    const hiddenElements = queryAllByRole('img', {hidden: true})
-
-    expect(await elements.count()).toEqual(1)
-    expect(await hiddenElements.count()).toEqual(2)
-  })
-
-  test.describe('querying by role with `level` option', () => {
-    test('retrieves the correct elements when querying all by role', async ({
-      queries: {queryAllByRole},
-    }) => {
-      const locator = queryAllByRole('heading')
-      const levelOneLocator = queryAllByRole('heading', {level: 3})
+    test('should handle the queryAll* methods', async ({queries}) => {
+      const {queryAllByText} = queries
+      const locator = queryAllByText(/Hello/)
 
       expect(await locator.count()).toEqual(3)
-      expect(await levelOneLocator.count()).toEqual(1)
+
+      const text = await Promise.all([
+        locator.nth(0).textContent(),
+        locator.nth(1).textContent(),
+        locator.nth(2).textContent(),
+      ])
+
+      expect(text).toEqual(['Hello h1', 'Hello h2', 'Hello h3'])
     })
 
-    test('does not throw when querying for a specific element', async ({queries: {getByRole}}) => {
-      await expect(getByRole('heading', {level: 3}).textContent()).resolves.not.toThrow()
+    test('should handle the queryAll* methods with a selector', async ({queries}) => {
+      const {queryAllByText} = queries
+      const locator = queryAllByText(/Hello/, {selector: 'h2'})
+
+      expect(await locator.count()).toEqual(1)
+
+      expect(await locator.textContent()).toEqual('Hello h2')
     })
-  })
 
-  test('scopes to container with `within`', async ({queries: {queryByRole}}) => {
-    const form = queryByRole('form', {name: 'User'})
+    test('should handle the getBy* methods with a selector', async ({queries}) => {
+      const {getByText} = queries
+      const locator = getByText(/Hello/, {selector: 'h2'})
 
-    const {queryByLabelText} = within(form)
+      expect(await locator.textContent()).toEqual('Hello h2')
+    })
 
-    const outerLocator = queryByLabelText('Name')
-    const innerLocator = queryByLabelText('Username')
+    test('should handle the getBy* methods with a regex name', async ({queries}) => {
+      const {getByRole} = queries
+      const element = getByRole('button', {name: /getBy.*Test/})
 
-    expect(await outerLocator.count()).toBe(0)
-    expect(await innerLocator.count()).toBe(1)
-  })
+      expect(await element.textContent()).toEqual('getByRole Test')
+    })
 
-  test.describe('configuration', () => {
-    test.describe('custom data-testeid', () => {
-      test.use({testIdAttribute: 'data-id'})
+    test('supports `hidden` option when querying by role', async ({queries: {queryAllByRole}}) => {
+      const elements = queryAllByRole('img')
+      const hiddenElements = queryAllByRole('img', {hidden: true})
 
-      test('supports custom data-testid attribute name', async ({queries}) => {
-        const locator = queries.getByTestId('second-level-header')
+      expect(await elements.count()).toEqual(1)
+      expect(await hiddenElements.count()).toEqual(2)
+    })
 
-        expect(await locator.textContent()).toEqual('Hello h2')
+    test.describe('querying by role with `level` option', () => {
+      test('retrieves the correct elements when querying all by role', async ({
+        queries: {queryAllByRole},
+      }) => {
+        const locator = queryAllByRole('heading')
+        const levelOneLocator = queryAllByRole('heading', {level: 3})
+
+        expect(await locator.count()).toEqual(3)
+        expect(await levelOneLocator.count()).toEqual(1)
+      })
+
+      test('does not throw when querying for a specific element', async ({
+        queries: {getByRole},
+      }) => {
+        await expect(getByRole('heading', {level: 3}).textContent()).resolves.not.toThrow()
       })
     })
 
-    test.describe('nested configuration', () => {
-      test.use({testIdAttribute: 'data-new-id'})
+    test('scopes to container with `within`', async ({queries: {queryByRole}}) => {
+      const form = queryByRole('form', {name: 'User'})
 
-      test('supports nested data-testid attribute names', async ({queries}) => {
-        const locator = queries.getByTestId('first-level-header')
+      const {queryByLabelText} = within(form)
 
-        expect(await locator.textContent()).toEqual('Hello h1')
+      const outerLocator = queryByLabelText('Name')
+      const innerLocator = queryByLabelText('Username')
+
+      expect(await outerLocator.count()).toBe(0)
+      expect(await innerLocator.count()).toBe(1)
+    })
+
+    test.describe('configuration', () => {
+      test.describe('custom data-testid', () => {
+        test.use({testIdAttribute: 'data-id'})
+
+        test('supports custom data-testid attribute name', async ({queries}) => {
+          const locator = queries.getByTestId('second-level-header')
+
+          expect(await locator.textContent()).toEqual('Hello h2')
+        })
+      })
+
+      test.describe('nested configuration', () => {
+        test.use({testIdAttribute: 'data-new-id'})
+
+        test('supports nested data-testid attribute names', async ({queries}) => {
+          const locator = queries.getByTestId('first-level-header')
+
+          expect(await locator.textContent()).toEqual('Hello h1')
+        })
       })
     })
   })


### PR DESCRIPTION
Refactors extracted from #488 to clean up the diff:
- Isolate 'standard' page (no timeout) in `describe` block so that both standard and deferred page tests have `beforeEach` and `afterEach` to open and close the page
- Rename `SupportedQueries` to `SynchronousQueries` in preparation to support `find*` queries
- Use queries from Testing Library to enumerate queries (instead of internal hard-coded query name array, with the intention of removing all of the legacy ElementHandle implementation in a future major release)
