### PR TITLE
♻️ Speed up tests, split out query helpers

### DIFF
--- a/lib/fixture/locator/fixtures.ts
+++ b/lib/fixture/locator/fixtures.ts
@@ -9,13 +9,8 @@ import type {
   Within,
 } from '../types'
 
-import {
-  buildTestingLibraryScript,
-  isAllQuery,
-  queriesFor,
-  queryToSelector,
-  synchronousQueryNames,
-} from './helpers'
+import {buildTestingLibraryScript, queryToSelector} from './helpers'
+import {isAllQuery, queriesFor, synchronousQueryNames} from './queries'
 
 type TestArguments = PlaywrightTestArgs & Config
 

--- a/lib/fixture/locator/helpers.ts
+++ b/lib/fixture/locator/helpers.ts
@@ -1,33 +1,8 @@
 import {promises as fs} from 'fs'
 
-import type {Locator, Page} from '@playwright/test'
-import {errors} from '@playwright/test'
-import {queries} from '@testing-library/dom'
-
 import {configureTestingLibraryScript} from '../../common'
-import {replacer, reviver} from '../helpers'
-import type {
-  AllQuery,
-  Config,
-  FindQuery,
-  GetQuery,
-  LocatorQueries as Queries,
-  Query,
-  QueryQuery,
-  Selector,
-  SynchronousQuery,
-} from '../types'
-
-const allQueryNames = Object.keys(queries) as Query[]
-
-const isAllQuery = (query: Query): query is AllQuery => query.includes('All')
-
-const isFindQuery = (query: Query): query is FindQuery => query.startsWith('find')
-const isNotFindQuery = (query: Query): query is Exclude<Query, FindQuery> =>
-  !query.startsWith('find')
-
-const findQueryToGetQuery = (query: FindQuery) => query.replace(/^find/, 'get') as GetQuery
-const findQueryToQueryQuery = (query: FindQuery) => query.replace(/^find/, 'query') as QueryQuery
+import {reviver} from '../helpers'
+import type {Config, Selector, SynchronousQuery} from '../types'
 
 const queryToSelector = (query: SynchronousQuery) =>
   query.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase() as Selector
@@ -47,75 +22,4 @@ const buildTestingLibraryScript = async ({config}: {config: Config}) => {
   `
 }
 
-const synchronousQueryNames = allQueryNames.filter(isNotFindQuery)
-
-const createFindQuery =
-  (
-    pageOrLocator: Page | Locator,
-    query: FindQuery,
-    {asyncUtilTimeout, asyncUtilExpectedState}: Partial<Config> = {},
-  ) =>
-  async (...[id, options, waitForElementOptions]: Parameters<Queries[FindQuery]>) => {
-    const synchronousOptions = ([id, options] as const).filter(Boolean)
-
-    const locator = pageOrLocator.locator(
-      `${queryToSelector(findQueryToQueryQuery(query))}=${JSON.stringify(
-        synchronousOptions,
-        replacer,
-      )}`,
-    )
-
-    const {state = asyncUtilExpectedState, timeout = asyncUtilTimeout} = waitForElementOptions ?? {}
-
-    try {
-      await locator.first().waitFor({state, timeout})
-    } catch (error) {
-      // In the case of a `waitFor` timeout from Playwright, we want to
-      // surface the appropriate error from Testing Library, so run the
-      // query one more time as `get*` knowing that it will fail with the
-      // error that we want the user to see instead of the `TimeoutError`
-      if (error instanceof errors.TimeoutError) {
-        return pageOrLocator
-          .locator(
-            `${queryToSelector(findQueryToGetQuery(query))}=${JSON.stringify(
-              synchronousOptions,
-              replacer,
-            )}`,
-          )
-          .first()
-          .waitFor({state, timeout: 100})
-      }
-
-      throw error
-    }
-
-    return locator
-  }
-
-/**
- * Given a `Page` or `Locator` instance, return an object of Testing Library
- * query methods that return a `Locator` instance for the queried element
- *
- * @internal this API is not currently intended for public usage and may be
- * removed or changed outside of semantic release versioning. If possible, you
- * should use the `locatorFixtures` with **@playwright/test** instead.
- * @see {@link locatorFixtures}
- *
- * @param pageOrLocator `Page` or `Locator` instance to use as the query root
- * @param config Testing Library configuration to apply to queries
- *
- * @returns object containing scoped Testing Library query methods
- */
-const queriesFor = (pageOrLocator: Page | Locator, config?: Partial<Config>) =>
-  allQueryNames.reduce(
-    (rest, query) => ({
-      ...rest,
-      [query]: isFindQuery(query)
-        ? createFindQuery(pageOrLocator, query, config)
-        : (...args: Parameters<Queries[SynchronousQuery]>) =>
-            pageOrLocator.locator(`${queryToSelector(query)}=${JSON.stringify(args, replacer)}`),
-    }),
-    {} as Queries,
-  )
-
-export {buildTestingLibraryScript, isAllQuery, queriesFor, queryToSelector, synchronousQueryNames}
+export {buildTestingLibraryScript, queryToSelector}

--- a/lib/fixture/locator/queries.ts
+++ b/lib/fixture/locator/queries.ts
@@ -1,0 +1,100 @@
+import type {Locator, Page} from '@playwright/test'
+import {errors} from '@playwright/test'
+import {queries} from '@testing-library/dom'
+
+import {replacer} from '../helpers'
+import type {
+  AllQuery,
+  Config,
+  FindQuery,
+  GetQuery,
+  LocatorQueries as Queries,
+  Query,
+  QueryQuery,
+  SynchronousQuery,
+} from '../types'
+
+import {queryToSelector} from './helpers'
+
+const isAllQuery = (query: Query): query is AllQuery => query.includes('All')
+
+const isFindQuery = (query: Query): query is FindQuery => query.startsWith('find')
+const isNotFindQuery = (query: Query): query is Exclude<Query, FindQuery> =>
+  !query.startsWith('find')
+
+const allQueryNames = Object.keys(queries) as Query[]
+const synchronousQueryNames = allQueryNames.filter(isNotFindQuery)
+
+const findQueryToGetQuery = (query: FindQuery) => query.replace(/^find/, 'get') as GetQuery
+const findQueryToQueryQuery = (query: FindQuery) => query.replace(/^find/, 'query') as QueryQuery
+
+const createFindQuery =
+  (
+    pageOrLocator: Page | Locator,
+    query: FindQuery,
+    {asyncUtilTimeout, asyncUtilExpectedState}: Partial<Config> = {},
+  ) =>
+  async (...[id, options, waitForElementOptions]: Parameters<Queries[FindQuery]>) => {
+    const synchronousOptions = ([id, options] as const).filter(Boolean)
+
+    const locator = pageOrLocator.locator(
+      `${queryToSelector(findQueryToQueryQuery(query))}=${JSON.stringify(
+        synchronousOptions,
+        replacer,
+      )}`,
+    )
+
+    const {state = asyncUtilExpectedState, timeout = asyncUtilTimeout} = waitForElementOptions ?? {}
+
+    try {
+      await locator.first().waitFor({state, timeout})
+    } catch (error) {
+      // In the case of a `waitFor` timeout from Playwright, we want to
+      // surface the appropriate error from Testing Library, so run the
+      // query one more time as `get*` knowing that it will fail with the
+      // error that we want the user to see instead of the `TimeoutError`
+      if (error instanceof errors.TimeoutError) {
+        return pageOrLocator
+          .locator(
+            `${queryToSelector(findQueryToGetQuery(query))}=${JSON.stringify(
+              synchronousOptions,
+              replacer,
+            )}`,
+          )
+          .first()
+          .waitFor({state, timeout: 100})
+      }
+
+      throw error
+    }
+
+    return locator
+  }
+
+/**
+ * Given a `Page` or `Locator` instance, return an object of Testing Library
+ * query methods that return a `Locator` instance for the queried element
+ *
+ * @internal this API is not currently intended for public usage and may be
+ * removed or changed outside of semantic release versioning. If possible, you
+ * should use the `locatorFixtures` with **@playwright/test** instead.
+ * @see {@link locatorFixtures}
+ *
+ * @param pageOrLocator `Page` or `Locator` instance to use as the query root
+ * @param config Testing Library configuration to apply to queries
+ *
+ * @returns object containing scoped Testing Library query methods
+ */
+const queriesFor = (pageOrLocator: Page | Locator, config?: Partial<Config>) =>
+  allQueryNames.reduce(
+    (rest, query) => ({
+      ...rest,
+      [query]: isFindQuery(query)
+        ? createFindQuery(pageOrLocator, query, config)
+        : (...args: Parameters<Queries[SynchronousQuery]>) =>
+            pageOrLocator.locator(`${queryToSelector(query)}=${JSON.stringify(args, replacer)}`),
+    }),
+    {} as Queries,
+  )
+
+export {allQueryNames, isAllQuery, isNotFindQuery, queriesFor, synchronousQueryNames}

--- a/test/fixture/element-handles.test.ts
+++ b/test/fixture/element-handles.test.ts
@@ -202,12 +202,12 @@ test.describe('lib/fixture.ts', () => {
 
     test('should handle the findBy* methods', async ({queries}) => {
       const {findByText} = queries
-      expect(await findByText('Loaded!', {}, {timeout: 7000})).toBeTruthy()
+      expect(await findByText('Loaded!', {}, {timeout: 3000})).toBeTruthy()
     })
 
     test('should handle the findByAll* methods', async ({queries}) => {
       const {findAllByText} = queries
-      const elements = await findAllByText(/Hello/, {}, {timeout: 7000})
+      const elements = await findAllByText(/Hello/, {}, {timeout: 3000})
       expect(elements).toHaveLength(2)
 
       const text = await Promise.all([elements[0].textContent(), elements[1].textContent()])

--- a/test/fixture/locators.test.ts
+++ b/test/fixture/locators.test.ts
@@ -180,13 +180,13 @@ test.describe('lib/fixture.ts (locators)', () => {
     test.afterEach(async ({page}) => page.close())
 
     test('should handle the findBy* methods', async ({queries}) => {
-      const locator = await queries.findByText('Loaded!', undefined, {timeout: 7000})
+      const locator = await queries.findByText('Loaded!', undefined, {timeout: 3000})
 
       expect(await locator.textContent()).toEqual('Loaded!')
     })
 
     test('should handle the findAllBy* methods', async ({queries}) => {
-      const locator = await queries.findAllByText(/Hello/, undefined, {timeout: 7000})
+      const locator = await queries.findAllByText(/Hello/, undefined, {timeout: 3000})
 
       const text = await Promise.all([locator.nth(0).textContent(), locator.nth(1).textContent()])
 
@@ -194,7 +194,7 @@ test.describe('lib/fixture.ts (locators)', () => {
     })
 
     test('throws Testing Library error when locator times out', async ({queries}) => {
-      const query = async () => queries.findByText(/Loaded!/, undefined, {timeout: 1000})
+      const query = async () => queries.findByText(/Loaded!/, undefined, {timeout: 500})
 
       await expect(query).rejects.toThrowError(
         expect.objectContaining({
@@ -204,7 +204,7 @@ test.describe('lib/fixture.ts (locators)', () => {
     })
 
     test('throws Testing Library error when multi-element locator times out', async ({queries}) => {
-      const query = async () => queries.findAllByText(/Hello/, undefined, {timeout: 1000})
+      const query = async () => queries.findAllByText(/Hello/, undefined, {timeout: 500})
 
       await expect(query).rejects.toThrowError(
         expect.objectContaining({
@@ -214,7 +214,7 @@ test.describe('lib/fixture.ts (locators)', () => {
     })
 
     test.describe('configuring asynchronous queries via `use`', () => {
-      test.use({asyncUtilTimeout: 7000})
+      test.use({asyncUtilTimeout: 3000})
 
       test('reads timeout configuration from `use` configuration', async ({queries, page}) => {
         // Ensure this test fails if we don't set `timeout` correctly in the `waitFor` in our find query
@@ -232,7 +232,7 @@ test.describe('lib/fixture.ts (locators)', () => {
       await expect(queries.getByText('Hidden')).toBeHidden()
 
       const locator = await queries.findByText('Hidden', undefined, {
-        timeout: 7000,
+        timeout: 3000,
         state: 'visible',
       })
 
@@ -245,7 +245,7 @@ test.describe('lib/fixture.ts (locators)', () => {
       test('waits for hidden element to be visible', async ({queries}) => {
         await expect(queries.getByText('Hidden')).toBeHidden()
 
-        const locator = await queries.findByText('Hidden', undefined, {timeout: 7000})
+        const locator = await queries.findByText('Hidden', undefined, {timeout: 3000})
 
         expect(await locator.textContent()).toEqual('Hidden')
       })
@@ -257,7 +257,7 @@ test.describe('lib/fixture.ts (locators)', () => {
       await expect(queries.queryByText('Attached')).toHaveCount(0)
 
       const locator = await queries.findByText('Attached', undefined, {
-        timeout: 7000,
+        timeout: 3000,
         state: 'attached',
       })
 
@@ -271,7 +271,7 @@ test.describe('lib/fixture.ts (locators)', () => {
       test('waits for hidden element to be attached', async ({queries}) => {
         await expect(queries.queryByText('Attached')).toHaveCount(0)
 
-        const locator = await queries.findByText('Attached', undefined, {timeout: 7000})
+        const locator = await queries.findByText('Attached', undefined, {timeout: 3000})
 
         expect(await locator.textContent()).toEqual('Attached')
         await expect(locator).toBeHidden()

--- a/test/fixtures/late-page.html
+++ b/test/fixtures/late-page.html
@@ -24,7 +24,7 @@
         attached.textContent = 'Attached'
         attached.style.visibility = 'hidden'
         document.body.appendChild(attached)
-      }, 5000)
+      }, 2000)
     </script>
   </body>
 </html>

--- a/test/standalone/index.test.ts
+++ b/test/standalone/index.test.ts
@@ -179,7 +179,7 @@ describe('lib/index.ts', () => {
       afterEach(async () => page.goto(`file://${path.join(__dirname, '../fixtures/page.html')}`))
 
       it('supports configuring timeout for findBy* queries', async () => {
-        configure({asyncUtilTimeout: 9000})
+        configure({asyncUtilTimeout: 3000})
 
         const element = await queries.findByText(await getDocument(page), 'Loaded!')
 


### PR DESCRIPTION
- test: speed up tests by only delaying 'late page' by 2 seconds
- refactor(fixture): split query-related stuff out into separate module
