### PR TITLE
✨ Add screen fixture API that combines queries with Page API

### DIFF
--- a/lib/fixture/index.ts
+++ b/lib/fixture/index.ts
@@ -2,21 +2,23 @@ import {Fixtures} from '@playwright/test'
 
 import type {Queries as ElementHandleQueries} from './element-handle'
 import {queriesFixture as elementHandleQueriesFixture} from './element-handle'
-import type {Queries as LocatorQueries} from './locator'
 import {
+  Queries as LocatorQueries,
   installTestingLibraryFixture,
   queriesFixture as locatorQueriesFixture,
   options,
   queriesFor,
   registerSelectorsFixture,
+  screenFixture,
   withinFixture,
 } from './locator'
-import type {Config} from './types'
+import type {Config, Screen} from './types'
 import {Within} from './types'
 
 const elementHandleFixtures: Fixtures = {queries: elementHandleQueriesFixture}
 const locatorFixtures: Fixtures = {
   queries: locatorQueriesFixture,
+  screen: screenFixture,
   within: withinFixture,
   registerSelectors: registerSelectorsFixture,
   installTestingLibrary: installTestingLibraryFixture,
@@ -29,6 +31,7 @@ interface ElementHandleFixtures {
 
 interface LocatorFixtures extends Partial<Config> {
   queries: LocatorQueries
+  screen: Screen
   within: Within
   registerSelectors: void
   installTestingLibrary: void

--- a/lib/fixture/locator/helpers.ts
+++ b/lib/fixture/locator/helpers.ts
@@ -22,4 +22,29 @@ const buildTestingLibraryScript = async ({config}: {config: Config}) => {
   `
 }
 
-export {buildTestingLibraryScript, queryToSelector}
+/**
+ * Alternative version of `Array.prototype.includes` that allows testing for
+ * the existence of an item with a type that is a _superset_ of the type of the
+ * items in the array.
+ *
+ * This allows us to use it to check whether an item of type `string` exists in
+ * an array of string literals (e.g: `['foo', 'bar'] as const`) without TypeScript
+ * complaining. It will, however, throw a compiler error if you try to pass an item
+ * of type `number`.
+ *
+ * @example
+ * const things = ['foo', 'bar'] as const;
+ *
+ * // error
+ * const hasThing = (t: string) => things.includes(t);
+ *
+ * // compiles
+ * const hasThing = (t: string) => includes(things, t);
+ *
+ * @param array array to search
+ * @param item item to search for
+ */
+const includes = <T extends U, U>(array: ReadonlyArray<T>, item: U): item is T =>
+  array.includes(item as T)
+
+export {buildTestingLibraryScript, includes, queryToSelector}

--- a/lib/fixture/locator/index.ts
+++ b/lib/fixture/locator/index.ts
@@ -3,6 +3,7 @@ export {
   options,
   queriesFixture,
   registerSelectorsFixture,
+  screenFixture,
   withinFixture,
 } from './fixtures'
 export type {Queries} from './fixtures'

--- a/lib/fixture/types.ts
+++ b/lib/fixture/types.ts
@@ -1,4 +1,4 @@
-import {Locator} from '@playwright/test'
+import {Locator, Page} from '@playwright/test'
 import type * as TestingLibraryDom from '@testing-library/dom'
 import {queries} from '@testing-library/dom'
 
@@ -51,7 +51,9 @@ type KebabCase<S> = S extends `${infer C}${infer T}`
   : S
 
 export type LocatorQueries = {[K in keyof Queries]: ConvertQuery<Queries[K]>}
+
 export type Within = (locator: Locator) => LocatorQueries
+export type Screen = LocatorQueries & Page
 
 export type Query = keyof Queries
 

--- a/test/fixture/locators.test.ts
+++ b/test/fixture/locators.test.ts
@@ -170,6 +170,16 @@ test.describe('lib/fixture.ts (locators)', () => {
         })
       })
     })
+
+    test('screen fixture responds to Page and Query methods', async ({screen}) => {
+      const locator = screen.getByRole('button', {name: /getBy.*Test/})
+      expect(await locator.textContent()).toEqual('getByRole Test')
+
+      await screen.goto(`file://${path.join(__dirname, '../fixtures/late-page.html')}`)
+
+      const delayedLocator = await screen.findByText('Loaded!', undefined, {timeout: 3000})
+      expect(await delayedLocator.textContent()).toEqual('Loaded!')
+    })
   })
 
   test.describe('deferred page', () => {


### PR DESCRIPTION
Thanks to @gajus for the [inspiration](https://github.com/testing-library/playwright-testing-library/issues/430#issuecomment-1227650435) here. This adds a `screen` fixture that combines Playwrights `page` API with the document-scoped Testing Library queries (`queries`). This will likely replace `queries` altogether in the official release of this stuff.

#### Example

```ts
test('screen fixture responds to Page and Query methods', async ({screen}) => {
  const locator = screen.getByRole('button', {name: /getBy.*Test/})
  expect(await locator.textContent()).toEqual('getByRole Test')

  await screen.goto(`file://${path.join(__dirname, '../fixtures/late-page.html')}`)

  const delayedLocator = await screen.findByText('Loaded!', undefined, {timeout: 3000})
  expect(await delayedLocator.textContent()).toEqual('Loaded!')
})
```