### PR TITLE
🐛 Don't surface 100ms timeout errors

### DIFF
--- a/lib/fixture/locator/index.ts
+++ b/lib/fixture/locator/index.ts
@@ -6,4 +6,4 @@ export {
   withinFixture,
 } from './fixtures'
 export type {Queries} from './fixtures'
-export {queriesFor} from './helpers'
+export {queriesFor} from './queries'

--- a/test/fixture/locators.test.ts
+++ b/test/fixture/locators.test.ts
@@ -203,6 +203,32 @@ test.describe('lib/fixture.ts (locators)', () => {
       )
     })
 
+    test('throws Playwright error when locator times out for visible state (but is attached)', async ({
+      queries,
+    }) => {
+      const query = async () =>
+        queries.findByText(/Hidden/, undefined, {state: 'visible', timeout: 500})
+
+      await expect(query).rejects.toThrowError(
+        expect.objectContaining({
+          message: expect.stringContaining('500'),
+        }),
+      )
+    })
+
+    test('throws Testing Library error when locator times out for attached state', async ({
+      queries,
+    }) => {
+      const query = async () =>
+        queries.findByText(/Loaded!/, undefined, {state: 'attached', timeout: 500})
+
+      await expect(query).rejects.toThrowError(
+        expect.objectContaining({
+          message: expect.stringContaining('TestingLibraryElementError'),
+        }),
+      )
+    })
+
     test('throws Testing Library error when multi-element locator times out', async ({queries}) => {
       const query = async () => queries.findAllByText(/Hello/, undefined, {timeout: 500})
 


### PR DESCRIPTION
Surface a ~less confusing error~ the original Playwright timeout error in the case an element is being waited upon via a `find*` query and it times out due to being hidden but still selectable. In this case we can't surface a Testing Library `get*` query error because it still finds the element. Right now that fails in the form of a hard-coded `100ms` Playwright `waitFor()`.

### Additional
- ~Bump down the delay on the "late page" to speed up the tests a bit~ #495 