### PR TITLE
✨ Support chaining queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,42 @@ test('my modal', async ({screen, within}) => {
 })
 ```
 
+#### Chaining
+
+> 🔖 Added in [**4.5.0**](https://github.com/testing-library/playwright-testing-library/releases/tag/v4.5.0)
+
+As an alternative to the `within(locator: Locator)` function you're familiar with from Testing Library, Playwright Testing Library also supports chaining queries together.
+
+All synchronous queries (`get*` + `query*`) return `Locator` instances are augmented with a `.within()` method (`TestingLibraryLocator`). All asynchronous queries (`find*`) return a special `LocatorPromise` that also supports `.within()`. This makes it possible to chain queries, including chaining `get*`, `query*` and `find*` interchangeably.
+
+> ⚠️ Note that including any `find*` query in the chain will make the entire chain asynchronous
+
+##### Synchronous
+
+```ts
+test('chaining synchronous queries', async ({screen}) => {
+  const locator = screen.getByRole('figure').within().findByRole('img')
+
+  expect(await locator.getAttribute('alt')).toEqual('Some image')
+})
+```
+
+##### Synchronous + Asynchronous
+
+```ts
+test('chaining synchronous queries + asynchronous queries', ({screen}) => {
+  //              ↓↓↓↓↓ including any `find*` queries makes the whole chain asynchronous
+  const locator = await screen
+    .getByTestId('modal-container') // Get "modal container" or throw (sync)
+    .within()
+    .findByRole('dialog') // Wait for modal to appear (async, until `asyncUtilTimeout`)
+    .within()
+    .getByRole('button', {name: 'Close'}) // Get close button within modal (sync)
+
+  expect(await locator.textContent()).toEqual('Close')
+})
+```
+
 #### Configuration
 
 The `Locator` query API is configured using Playwright's `use` API. See Playwright's documentation for [global](https://playwright.dev/docs/api/class-testconfig#test-config-use), [project](https://playwright.dev/docs/api/class-testproject#test-project-use), and [test](https://playwright.dev/docs/api/class-test#test-use).

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ test('my form', async ({screen, within}) => {
 
 #### Async Methods
 
-The `findBy` queries work the same way as they do in [Testing Library core](https://testing-library.com/docs/dom-testing-library/api-async) in that they return `Promise<Locator>` and are intended to be used to defer test execution until an element appears on the page.
+The `findBy` queries work the same way as they do in [Testing Library](https://testing-library.com/docs/dom-testing-library/api-async) core in that they return `Promise<Locator>` and are intended to be used to defer test execution until an element appears on the page.
 
 ```ts
 test('my modal', async ({screen, within}) => {

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ There are currently a few different ways to use Playwright Testing Library, depe
 
 ### Playwright Test Fixture
 
+> 🔖 Added in [**4.4.0**](https://github.com/testing-library/playwright-testing-library/releases/tag/v4.4.0)
+
 Using the `Locator` Playwright Test (**@playwright/test**) fixture with **@playwright-testing-library/test**.
 
 #### Setup

--- a/lib/fixture/locator/fixtures.ts
+++ b/lib/fixture/locator/fixtures.ts
@@ -1,10 +1,11 @@
-import type {Locator, PlaywrightTestArgs, TestFixture} from '@playwright/test'
-import {Page, selectors} from '@playwright/test'
+import type {PlaywrightTestArgs, TestFixture} from '@playwright/test'
+import {selectors} from '@playwright/test'
 
 import type {TestingLibraryDeserializedFunction as DeserializedFunction} from '../helpers'
 import type {
   Config,
   LocatorQueries as Queries,
+  QueryRoot,
   Screen,
   SelectorEngine,
   SynchronousQuery,
@@ -47,10 +48,10 @@ const withinFixture: TestFixture<Within, TestArguments> = async (
   {asyncUtilExpectedState, asyncUtilTimeout},
   use,
 ) =>
-  use(<Root extends Page | Locator>(root: Root) =>
+  use(<Root extends QueryRoot>(root: Root) =>
     'goto' in root
-      ? screenFor(root, {asyncUtilExpectedState, asyncUtilTimeout}).proxy
-      : (queriesFor(root, {asyncUtilExpectedState, asyncUtilTimeout}) as WithinReturn<Root>),
+      ? (screenFor(root, {asyncUtilExpectedState, asyncUtilTimeout}).proxy as WithinReturn<Root>)
+      : (queriesFor<Root>(root, {asyncUtilExpectedState, asyncUtilTimeout}) as WithinReturn<Root>),
   )
 
 type SynchronousQueryParameters = Parameters<Queries[SynchronousQuery]>

--- a/lib/fixture/locator/index.ts
+++ b/lib/fixture/locator/index.ts
@@ -1,3 +1,6 @@
+export type {Queries} from './fixtures'
+export type {LocatorPromise} from './queries'
+
 export {
   installTestingLibraryFixture,
   options,
@@ -6,5 +9,4 @@ export {
   screenFixture,
   withinFixture,
 } from './fixtures'
-export type {Queries} from './fixtures'
 export {queriesFor} from './queries'

--- a/lib/fixture/locator/queries.ts
+++ b/lib/fixture/locator/queries.ts
@@ -1,5 +1,5 @@
-import type {Locator, Page} from '@playwright/test'
-import {errors} from '@playwright/test'
+import type {Page} from '@playwright/test'
+import {Locator, errors} from '@playwright/test'
 import {queries} from '@testing-library/dom'
 
 import {replacer} from '../helpers'
@@ -9,13 +9,18 @@ import type {
   FindQuery,
   GetQuery,
   LocatorQueries as Queries,
+  QueriesReturn,
   Query,
   QueryQuery,
+  QueryRoot,
   Screen,
   SynchronousQuery,
+  TestingLibraryLocator,
 } from '../types'
 
 import {includes, queryToSelector} from './helpers'
+
+type SynchronousQueryParameters = Parameters<Queries[SynchronousQuery]>
 
 const isAllQuery = (query: Query): query is AllQuery => query.includes('All')
 
@@ -29,60 +34,115 @@ const synchronousQueryNames = allQueryNames.filter(isNotFindQuery)
 const findQueryToGetQuery = (query: FindQuery) => query.replace(/^find/, 'get') as GetQuery
 const findQueryToQueryQuery = (query: FindQuery) => query.replace(/^find/, 'query') as QueryQuery
 
-const createFindQuery =
-  (
-    pageOrLocator: Page | Locator,
-    query: FindQuery,
-    {asyncUtilTimeout, asyncUtilExpectedState}: Partial<Config> = {},
-  ) =>
-  async (...[id, options, waitForElementOptions]: Parameters<Queries[FindQuery]>) => {
-    const synchronousOptions = ([id, options] as const).filter(Boolean)
+class LocatorPromise extends Promise<Locator> {
+  /**
+   * Wrap an `async` function `Promise` return value in a `LocatorPromise`.
+   * This allows us to use `async/await` and still return a custom
+   * `LocatorPromise` instance instead of `Promise`.
+   *
+   * @param fn
+   * @returns
+   */
+  static wrap<A extends any[]>(fn: (...args: A) => Promise<Locator>, config: Partial<Config>) {
+    return (...args: A) => LocatorPromise.from(fn(...args), config)
+  }
 
-    const locator = pageOrLocator.locator(
-      `${queryToSelector(findQueryToQueryQuery(query))}=${JSON.stringify(
-        synchronousOptions,
-        replacer,
-      )}`,
-    )
+  static from(promise: Promise<Locator>, config: Partial<Config>) {
+    return new LocatorPromise((resolve, reject) => {
+      promise.then(resolve).catch(reject)
+    }, config)
+  }
 
-    const {state: expectedState = asyncUtilExpectedState, timeout = asyncUtilTimeout} =
-      waitForElementOptions ?? {}
+  config: Partial<Config>
 
-    try {
-      await locator.first().waitFor({state: expectedState, timeout})
-    } catch (error) {
-      // In the case of a `waitFor` timeout from Playwright, we want to
-      // surface the appropriate error from Testing Library, so run the
-      // query one more time as `get*` knowing that it will fail with the
-      // error that we want the user to see instead of the `TimeoutError`
-      if (error instanceof errors.TimeoutError) {
-        const timeoutLocator = pageOrLocator
-          .locator(
-            `${queryToSelector(findQueryToGetQuery(query))}=${JSON.stringify(
-              synchronousOptions,
-              replacer,
-            )}`,
-          )
-          .first()
+  constructor(
+    executor: (
+      resolve: (value: Locator | PromiseLike<Locator>) => void,
+      reject: (reason?: any) => void,
+    ) => void,
+    config: Partial<Config>,
+  ) {
+    super(executor)
 
-        // Handle case where element is attached, but hidden, and the expected
-        // state is set to `visible`. In this case, dereferencing the
-        // `Locator` instance won't throw a `get*` query error, so just
-        // surface the original Playwright timeout error
-        if (expectedState === 'visible' && !(await timeoutLocator.isVisible())) {
-          throw error
+    this.config = config
+  }
+
+  within() {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return queriesFor(this, this.config)
+  }
+}
+
+const locatorFor = (
+  root: Exclude<QueryRoot, Promise<any>>,
+  query: SynchronousQuery,
+  options: SynchronousQueryParameters,
+) => root.locator(`${queryToSelector(query)}=${JSON.stringify(options, replacer)}`)
+
+const augmentedLocatorFor = (
+  root: Exclude<QueryRoot, Promise<any>>,
+  query: SynchronousQuery,
+  options: SynchronousQueryParameters,
+  config: Partial<Config>,
+) => {
+  const locator = locatorFor(root, query, options)
+
+  return new Proxy(locator, {
+    get(target, property, receiver) {
+      return property === 'within'
+        ? // eslint-disable-next-line @typescript-eslint/no-use-before-define
+          () => queriesFor(target, config)
+        : Reflect.get(target, property, receiver)
+    },
+  }) as TestingLibraryLocator
+}
+
+const createFindQuery = (
+  root: QueryRoot,
+  query: FindQuery,
+  {asyncUtilTimeout, asyncUtilExpectedState}: Partial<Config> = {},
+) =>
+  LocatorPromise.wrap(
+    async (...[id, options, waitForElementOptions]: Parameters<Queries[FindQuery]>) => {
+      const settledRoot = root instanceof LocatorPromise ? await root : root
+      const synchronousOptions = (options ? [id, options] : [id]) as SynchronousQueryParameters
+
+      const locator = locatorFor(settledRoot, findQueryToQueryQuery(query), synchronousOptions)
+      const {state: expectedState = asyncUtilExpectedState, timeout = asyncUtilTimeout} =
+        waitForElementOptions ?? {}
+
+      try {
+        await locator.first().waitFor({state: expectedState, timeout})
+      } catch (error) {
+        // In the case of a `waitFor` timeout from Playwright, we want to
+        // surface the appropriate error from Testing Library, so run the
+        // query one more time as `get*` knowing that it will fail with the
+        // error that we want the user to see instead of the `TimeoutError`
+        if (error instanceof errors.TimeoutError) {
+          const timeoutLocator = locatorFor(
+            settledRoot,
+            findQueryToGetQuery(query),
+            synchronousOptions,
+          ).first()
+
+          // Handle case where element is attached, but hidden, and the expected
+          // state is set to `visible`. In this case, dereferencing the
+          // `Locator` instance won't throw a `get*` query error, so just
+          // surface the original Playwright timeout error
+          if (expectedState === 'visible' && !(await timeoutLocator.isVisible())) {
+            throw error
+          }
+
+          // In all other cases, dereferencing the `Locator` instance here should
+          // cause the above `get*` query to throw an error in Testing Library
+          await timeoutLocator.waitFor({state: expectedState, timeout})
         }
-
-        // In all other cases, dereferencing the `Locator` instance here should
-        // cause the above `get*` query to throw an error in Testing Library
-        return timeoutLocator.waitFor({state: expectedState, timeout})
       }
 
-      throw error
-    }
-
-    return locator
-  }
+      return locator
+    },
+    {asyncUtilExpectedState, asyncUtilTimeout},
+  )
 
 /**
  * Given a `Page` or `Locator` instance, return an object of Testing Library
@@ -93,21 +153,26 @@ const createFindQuery =
  * should use the `locatorFixtures` with **@playwright/test** instead.
  * @see {@link locatorFixtures}
  *
- * @param pageOrLocator `Page` or `Locator` instance to use as the query root
+ * @param root `Page` or `Locator` instance to use as the query root
  * @param config Testing Library configuration to apply to queries
  *
  * @returns object containing scoped Testing Library query methods
  */
-const queriesFor = (pageOrLocator: Page | Locator, config?: Partial<Config>) =>
+const queriesFor = <Root extends QueryRoot>(
+  root: Root,
+  config: Partial<Config>,
+): QueriesReturn<Root> =>
   allQueryNames.reduce(
     (rest, query) => ({
       ...rest,
       [query]: isFindQuery(query)
-        ? createFindQuery(pageOrLocator, query, config)
-        : (...args: Parameters<Queries[SynchronousQuery]>) =>
-            pageOrLocator.locator(`${queryToSelector(query)}=${JSON.stringify(args, replacer)}`),
+        ? createFindQuery(root, query, config)
+        : (...options: SynchronousQueryParameters) =>
+            root instanceof LocatorPromise
+              ? root.then(r => locatorFor(r, query, options))
+              : augmentedLocatorFor(root, query, options, config),
     }),
-    {} as Queries,
+    {} as QueriesReturn<Root>,
   )
 
 const screenFor = (page: Page, config: Partial<Config>) =>
@@ -119,4 +184,12 @@ const screenFor = (page: Page, config: Partial<Config>) =>
     },
   }) as {proxy: Screen; revoke: () => void}
 
-export {allQueryNames, isAllQuery, isNotFindQuery, queriesFor, screenFor, synchronousQueryNames}
+export {
+  LocatorPromise,
+  allQueryNames,
+  isAllQuery,
+  isNotFindQuery,
+  queriesFor,
+  screenFor,
+  synchronousQueryNames,
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ const config: PlaywrightTestConfig = {
   reporter: 'list',
   testDir: 'test/fixture',
   use: {actionTimeout: 3000},
+  timeout: 5 * 1000,
 }
 
 export default config

--- a/test/fixtures/chaining.html
+++ b/test/fixtures/chaining.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <figure id="figure">
+      <div id="image">Loading...</div>
+      <figcaption data-customid="some-image-caption">Some image</figcaption>
+    </figure>
+    <div
+      id="modal-container"
+      data-testid="modal-container"
+      data-customid="modal-container-custom-id"
+    />
+    <script>
+      setTimeout(() => {
+        const image = document.createElement('img')
+
+        image.src =
+          'data:image/png;base64,/9j/4AAQSkZJRgABAQEAYABgAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2ODApLCBxdWFsaXR5ID0gNjUK/9sAQwALCAgKCAcLCgkKDQwLDREcEhEPDxEiGRoUHCkkKyooJCcnLTJANy0wPTAnJzhMOT1DRUhJSCs2T1VORlRAR0hF/9sAQwEMDQ0RDxEhEhIhRS4nLkVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVF/8AAEQgAjABgAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8Aaq+1TItTrCM0vlYI7VyHVcaBgU6lCYJ9KfsAGaBXGijOKRZFLYBFEnAoAcrZp4xUKkCn76AFeomWlLjdyeByarvPvfbGpZz0VetFrhewSECozg1Mmm3E7DfKkeP4QN2Pxol024gIO5XQ9xRyMFUWxHDqaEbZQUYdQ1SNqEQBBcZWsq4mQoWjIZPQisy5G9C9vlWHVc8EVaiZ8xuSaxGcgHBqs2sM0fXmsaLmI7wQR603zg0WQORxVcpPMzROosrZ3YJqR9YkaNV9Oc1gSXG1gPfFTLL+7Y+2KOUOZm0NXYipf7XJkAXJJ4AHU1gQy70K8ZNX7VzbYZRmToD6UWQXZtxQ3N0+JCIlbHHVsfStmGO1sYtjMFY/wj5nP1rlE1B42aQsy59DzSGeedNxPlxMcBe70LQLN7nQXeu2sJ8tTux/CD39z3qBNTkvFUY2Kedo4rAltJYSGkTYW6BuuP6Vv2FsFiVj1x1qJMuMdTJaOQAiRRj2qKOFFfDd+4rRuixJBOce3NZzOFOMVojJsjv41jgOz8/Wsi2fh/X0rUuW823YHOAOKwIrh4JmOMjvV2EOkYGVWbgA9KsI26OQ8DHaqs7F8OOhOaYs5WEgZ3OaQFu0Y+b1GM4rVjkUDORmsG1bbLljzV/f75qWUjXtQkkmXAP16CtYzGJf9BhUy4x5z44+lczDMRir0eoLCMtlj6VFyrFuLR7qe5FxdygtnJ+bNdBFLEgCZBx6Vy0esTTMyu+Exwq1qaUS65MnB7VLsUrlJ3eVgSvT0NU7txFljnPtWmICq9we1ULySKCJjccEevNbIxKCztfBo0+VgOhHWqml2z3M9zAy5O0n6VB9vImWWKCQqpzuAro/D1pHqEV3f2MjeegxJCRj8RViOZmUxDYeqnHNJaQGW4QYyqmtnVLUTQiRF+Ythqht4vKVMDLtx9ahuxSRl2kAfUpVkbCKSSfanq+bghM4zgZrS161TT7mC0tVHnzJvkkPX/PWsZLdy8nlXG5kPPvTWquD0NiLIUZHJqSVAilsHpWXBqDwopeMsDxn3rRi1JJV2slZtMtMrROxlwowK37OZrWLJeqVvbo53KPl96L+5jhtiOQ3apY0xt9rExJSNcDsazyk81vNPcsXC4GPQGtafTN0eSCGHPHNZH2qa0lZSA8ZG1lPQitzEn1Ce5uBZJaeWsEa7fk4GM5yfepvDmrnT/FeYhmGVdkoHQ+/51UhttMJ3SveqOpjj28/jn+lXr19MNhHDpFhLbsMl5pGyT+NU3cSVjbvokF/cgDETHcvoAeaytpa+gKj5EkBxUum3AkjH2qQkRqBzVPVJ4kGYMr3FZNMtMzNcnnuNemnVTIEAVgo6AVSjnhhZzDG5d/4SOBV/T766sJpJYCCzjkuM0241C/lcu7JuPdI1H9KabWgPXUjwtvbRxyH94csR6ZqxaWwddxOCelZ8EDzSknv1ya6C0WKJQijd61MnYpE1qDG20KSKg1aTC7RGM+prWSVFjyqjI7Vzeq3JnlbLhAO1StWUdjPdtboQIiR7Cuc1COK43OsTiQ+grqojHNGBuzn15pHs1BJVSTjOQK2MDktO02ZpwpiGW5AY4rWj0+5Nx5JCuCQCqHpWrBEiSBiAGXnFXStrlZPKQuOuUIP86nUZzWsWN1oFwZmg8yB8bWHasOa6m1GZLeCMF34HPSu41e/WazMRjTZjGGJORXJaMi2N1M/lhSW+Vm7D0qXI1jHQlvNDNrDGsk6Zx8+OTn6VNb6XC1uFWR3Ho6bcVr+a8xz0XuUUU98L1J59Tms7sdkYP8AZUMTEBc596t29pHGOFP4mrpRWPPNRyDHAYqfejUBjGGNDgru9BXOahAs0hKIM+1dAlr5r8nP0qZtHDfdSqigbsT6fLH5q/MTH6etd1ZxQvCPKjVQwxkivPIbSKGZDaSgAHlSetd9ow82yXeffrRJu9iEtLlo6FaNOS0QY4z+NVZNBjUlIxtzyO+K6GIbFRm6sKeUWOQFhndVJCOF1Dw9vG7YSB1IrGOkxqzsyHHbivUxbIyMp656VWm0+Bl2yRhiOnFJxuNOx5i0whygXGKp3crmIsmeORXd6r4Rt7sbkTypCPvLWFJ4MvUjZYpVYf7QqUh3OVimmL5IIXvV0B50xw3oe/0NS3ehahaP5ZUuPVV4qOOKSE/OpU9DgUxlnT7eRJAJFYDPpXY2lgjRjAz9a4+J7jzFO7gGu30hy0S7j2rWna5Ejze1sIxeL5TkgnoT0rvdLVogsIJrmtK0tmukmI+VOtddawl51lHCp+tc7blK5WysbkKmUKmfudasEea6t/cqC2+SN5PU1OrCKMk/x81uiB4X94XB4xRuSQHHaodxijB9aZkpFkfeJouMfE3mPz91ac8YLbv4abgRW5X+I81BPdeXAF/iqdtwFmt0kkACjpVN9HtXDbo1JPtV6FiEVm6mnsPm+tFguYEvh23Qfu1A78VZtLNbZOB0rVCgZDUxYcqfShXWwbmJbWawK5OBu7Vfs40FtsPykmm3wH2dccdKl/5axrgYwKEkgLzKEVYh0IpHILKp/hpkbk3K5NLIM3LD/ZzVCGSFpHCD7tS7fmU9QtQwEljUsPMUlJANlk3yZH3RVF0824ODkCrGT9neqVq5yxzzQBoRHeuM/dqdjnBHaqtkThverAPyNTASTkDB61KjBY8d6rKctzTmY+YBSQz/2Q=='
+        image.alt = 'Some image'
+        image.dataset.customid = 'some-image'
+
+        const input = document.createElement('input')
+
+        input.type = 'text'
+        input.value = 'Input'
+
+        const modal = document.createElement('dialog')
+        const modalDiv = document.createElement('div')
+        const modalImage = image.cloneNode()
+
+        modalImage.dataset = null
+        modalImage.alt = 'Some modal image'
+
+        modalDiv.dataset.testid = 'image-container'
+        modalDiv.appendChild(modalImage)
+
+        modal.style.display = 'block'
+        modal.appendChild(input)
+        modal.appendChild(modalDiv)
+
+        // Attach modal
+        document.querySelector('#modal-container').appendChild(modal)
+
+        // Attach image
+        document.querySelector('#figure').replaceChild(image, document.querySelector('#image'))
+
+        // Update modal (+2000ms)
+        setTimeout(() => {
+          modalImage.dataset.customid = 'second-image'
+          modalImage.src =
+            'data:image/png;base64,/9j/4AAQSkZJRgABAQEAYABgAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2ODApLCBxdWFsaXR5ID0gNjUK/9sAQwALCAgKCAcLCgkKDQwLDREcEhEPDxEiGRoUHCkkKyooJCcnLTJANy0wPTAnJzhMOT1DRUhJSCs2T1VORlRAR0hF/9sAQwEMDQ0RDxEhEhIhRS4nLkVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVF/8AAEQgAiwBgAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A62mmlpDVklSa4ELgOetODh1yDVe+0+PUsJM7oi8/IcHP1ql5E2juq+c81o5wGf7yH3PcGp50nYfK2rmxH92nt0qCCdWAHr0qUnimAqmlc9aYh5pXPFJ7AiFjwark4NWG6VVY8moKEU5lq03QVTiOZaut9ymIt5prHijNRythTzirJI5M4HGcmmyxrPA0bDIIxiopnEwRDuBI4YfWoWkmhUkMHA7N1rGWptHQzoL02szW1wcMnKk/xLWhHqsDtgSqTjPWuU8QXUdwrcskqHKt/MVzsTSMWKyHj0NVGWhLjqerx3KM2AwP40+SUAZzXl1rqV5ayqUlJ9ieK1rXxRMW23BBBPJ6YptisdqJN2eeKqy3EaZJYYrG/ts3R8mxjaZ/Reg+p7VKmkNcDfqU5Yf88YjhfxPU1DkkUlcs2t8ktyQjLge9bGSUya5+HTLGG/iktoTGynsTg/Wt5zhaadyWrFwmsXWdRFtCVSQCQ8AZrUlcqvFcZrA8+/DFvuHoK0bsJIvy6ou+0eMsdihWB7+tGoakdpMbds1jSMZsBTtA4zUciPtO0F8DoOprA2RlXdw8srb2+U802B1W2Uw8Zb5iasXdjJE1s7qczsMA1DdW0lrc3ESL8ofIpkiOwaN22gbF6+9QWvlMwMy71/ug4zUbrI8LMx2Rg/8AfTUkP31PQDimI7PSblEiCxxiKPsoGK0pLuE5UsGY/wAK1kaRMvl7SoJ9TV/zkWcKgUHqT6UlbcZd0+LEpcqAewrQnb5azdMujdO8m1gpPBPAxV6Y5U1RJPc/cJzgiuK1SB/tbPHmUN1GeRXY3bER4FclcyEXxAcr64FVLYUdzHks7t/9bIyR9QPStmwtZYNLiuUvAGmkEYJTOz1zSvaT3CkLICpHpipNHh2JLZajHIIGOcp1B7MKzTLaNDQyurXf2S9YXMcZYxSMgVlcfTqP8Kzb+zHnNvzuyc1oWYi0vxJAEvmul2HaNuMZHU1JIYft4kuWAijJc5745xQ9QV0Y934ZldLRp5Ire3XLFXbBNYt3YyQ3LBYwIR0IOav6jqTanPcTuiiUn92svIC56CmXFtJaaXHcA7dzkiJifu+o/WqsTfUpR3stscA4z7VaW/Edu42kyyjbvY9Ky2ufMkAeIqe3NTbgwHTNTYq51vh5v3XBJrYnOEPNYvhyPbDk9617ggjFUSPvn2oSTj3rkbu5JuWKFmb6V1N84KnmuXuiI5zsXdu79qqQkaemaisjBJUw+O65rZFrHqELRBmicDKsmM/rXF/a3ibbwT1weAvvWjYavOkyM3zAe9Q1cpOxp6jYPosUF46bsnbJIvY9ifrWNcTPrLSRw5EaAlpMHArsb6Jdb0uSO3nUxvhWRux9KiDx6dZLbyRokajaAmAKXKVzGDFrTDTo4UhgkaEYDGPLfrXOX8tzfztLcblQf3q6q6m81gY4cxg4yx6Vn3sm1dpCxZ7ryDRqLQ55lhkj+ZghUcGmW8WWLHt0p1w2WIbBA/ip9tknaDwaAOy0QBLUcYGKtXDVRsLhIrdVbripJbkORjpRzIXKzKmu2JwXOKEXeVbzAce1Z00gz1/KpIGm8lpIjlVGWUjqKiBpMtPbm4JRkIyeGHcVG2mS2XzR/MD2yafp6yM5zIVj7ZJrVZZCmFOR2rR6ELUwLfUby0lIjkbJP3VPWpLjVZ2bE4Yk88+tTzRpDcgkfOew7U5rXz+o5ApXCxmtfyOr+U2GPOP8/Q1Cxlbl9xQ9c9q03skUqVUAnPWoLo7IsygAr0Ap3EUPKX+EHb7inREJJgEY9M1G9wzKSXBPYY6VlzXDhs7zmhq4J2OygkygqYPxg+lcxp2s7PkmYn0JrbiuGkTcoDKe4rnlBo3jNMUW6H+EZpdkkSsYiBxyPUd6uBVHenw4MmCOvFaoyZFbyQNbBd6gr2FW7e6TgO4VSOCaptZweYRJCRjoRVWWyjOSsrDbwMmrINp7RHYFACzc59BVZ7domLE9Qc+9Q2d+bV0SQ71xgnNLqNxJcuI4BtJ7+1RYu5HcF5WLRkDjGKzZpYlU+eTv9Kn/ALPuoyT54z71nXttdeeUkCHHRhVohjoYFlDlv4ugHas280plJaI59jWpbp5PGee5qycOMMPxqW2mVZNHINE6NgqRW34fmnEpjIJjI79qumzVm6irFvD5J4ahyugUbM1doHAHNBU8jAOakZSnLcn2pi4Lgbio65PJpDGLavFuKSuwI5QtSKkPk7COeuBUs5WPgM3mBfMOegWs8zv5mGAPQkjjNWyRs9rhuOOPyqewgmLM5Y/L+tMmvFds7eMdavadJmxcjGT61IyO/wAhCUKncOUaseWViuFgKn+8TnFaU10qfLKFbPTNUZzkAhCB1zimgKyI4GXp6lh0BwakDLgEdDTg1RcdhFJx2FSKRn1qMZPTpTgpLcDFAzdaJkyroVA9ajcAgoejCtaJ2ZJSxztAxnmnXdtFsX5AMk5xx3qFK5bjY567spLg5FwygoY2BAPBqrLpczurfaOnUAVqsBke+aGPyD2zV8zI5UZMem7TgNuz3qSRp7WFlVCcYA2DPHer0XMe49ae/DnHtRcLGSswWDlcTSvk7h0//VTZZiiIqfPhu3QLWoACeRmk8pNudop3FYxEVhyBUgU5HHFaRRQcADFV34zjtSKItjL2zn0pSpA+6alP3PxoUfLSA//Z'
+
+          const alert = document.createElement('span')
+
+          alert.textContent = 'Updated'
+          alert.setAttribute('role', 'alert')
+          alert.setAttribute('aria-live', 'polite')
+
+          const close = document.createElement('button')
+
+          close.textContent = 'Close'
+
+          alert.appendChild(close)
+          modalDiv.appendChild(alert)
+        }, 2000)
+      }, 2000)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
> - [x] ⚠️ This depends on #498, so merge it first

Implement query chaining per response to @gajus comment https://github.com/testing-library/playwright-testing-library/pull/498#issuecomment-1241427489.

I think this came out to be pretty cool/useful/powerful.

#### Synchronous

```ts
test('chaining synchronous queries', async ({screen}) => {
  const locator = screen.getByRole('figure').within().getByText('Some image')

  expect(await locator.textContent()).toEqual('Some image')
})
```
    
#### Synchronous + Asynchronous
```ts
test('chaining multiple asynchronous queries between synchronous queries', >
  const locator = await screen // <--- including any `find*` queries makes the whole chain asynchronous
    .getByTestId('modal-container') // Get "modal container" (sync)
    .within()
    .findByRole('dialog') // Wait for modal to appear (async, until `asyncUtilTimeout`)
    .within()
    .findByRole('alert') // Wait for alert to appear in modal (async as well)
    .within()
    .getByRole('button', {name: 'Close'}) // Find close button in alert (sync)

  expect(await locator.textContent()).toEqual('Close')
})
```

-------

### Todo
- [x] Pass configuration through the chain
- [x] Test for chained asynchronous queries