### PR TITLE
🔊 Improve error message for invalid function matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,21 @@ Unique methods, not part of **@testing-library/dom**
 - Async utilities `waitForElement`, `waitForElementToBeRemoved` and `waitForDomChange` are not exposed. Consider using a `find*` query or a Playwright built-in like [`Locator.waitFor()`](https://playwright.dev/docs/api/class-locator#locator-wait-for).
 - The `fireEvent` method is not exposed, use Playwright's built-ins instead.
 - Assertion extensions from [**jest-dom**](https://testing-library.com/docs/ecosystem-jest-dom/) are not compatible, use Playwright Test if possible.
-- The [`getNodeText()`](https://testing-library.com/docs/dom-testing-library/api-custom-queries/#getnodetext) function is not currently supported for `Locator`.
+
+### Locator Queries
+
+- The [`getNodeText()`](https://testing-library.com/docs/dom-testing-library/api-custom-queries/#getnodetext) function is currently unsupported.
+- When using a function for [`TextMatch`](https://testing-library.com/docs/queries/about/#textmatch), the function cannot reference its closure scope
+
+  ```ts
+  // ✅ This is supported
+  screen.getByText(content => content.startsWith('Foo'))
+
+  // ❌ This is not supported
+  const startsWithFoo = (content: string) => content.startsWith('Foo')
+
+  screen.getByText(content => startsWithFoo(content))
+  ```
 
 ## Special Thanks
 

--- a/lib/fixture/helpers.ts
+++ b/lib/fixture/helpers.ts
@@ -1,3 +1,13 @@
+class TestingLibraryDeserializedFunction extends Function {
+  original: string
+
+  constructor(fn: string) {
+    super(`return (${fn}).apply(this, arguments)`)
+
+    this.original = fn
+  }
+}
+
 const replacer = (_: string, value: unknown) => {
   if (value instanceof RegExp) return `__REGEXP ${value.toString()}`
   if (typeof value === 'function') return `__FUNCTION ${value.toString()}`
@@ -13,11 +23,10 @@ const reviver = (_: string, value: string) => {
   }
 
   if (value.toString().includes('__FUNCTION ')) {
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval
-    return new Function(`return (${value.split('__FUNCTION ')[1]}).apply(this, arguments)`)
+    return new TestingLibraryDeserializedFunction(value.split('__FUNCTION ')[1])
   }
 
   return value
 }
 
-export {replacer, reviver}
+export {TestingLibraryDeserializedFunction, replacer, reviver}

--- a/lib/fixture/locator/fixtures.ts
+++ b/lib/fixture/locator/fixtures.ts
@@ -1,6 +1,7 @@
 import type {Locator, PlaywrightTestArgs, TestFixture} from '@playwright/test'
 import {Page, selectors} from '@playwright/test'
 
+import type {TestingLibraryDeserializedFunction as DeserializedFunction} from '../helpers'
 import type {
   Config,
   LocatorQueries as Queries,
@@ -52,38 +53,71 @@ const withinFixture: TestFixture<Within, TestArguments> = async (
       : (queriesFor(root, {asyncUtilExpectedState, asyncUtilTimeout}) as WithinReturn<Root>),
   )
 
+type SynchronousQueryParameters = Parameters<Queries[SynchronousQuery]>
+
 declare const queryName: SynchronousQuery
+declare class TestingLibraryDeserializedFunction extends DeserializedFunction {}
 
-const engine: () => SelectorEngine = () => ({
-  query(root, selector) {
-    const args = JSON.parse(selector, window.__testingLibraryReviver) as unknown as Parameters<
-      Queries[typeof queryName]
-    >
-
-    if (isAllQuery(queryName))
-      throw new Error(
-        `PlaywrightTestingLibrary: the plural '${queryName}' was used to create this Locator`,
+const engine: () => SelectorEngine = () => {
+  const getError = (error: unknown, matcher: SynchronousQueryParameters[0]) => {
+    if (typeof matcher === 'function' && error instanceof ReferenceError) {
+      return new ReferenceError(
+        [
+          error.message,
+          '\n⚠️ A ReferenceError was thrown when using a function TextMatch, did you reference external scope in your matcher function?',
+          '\nProvided matcher function:',
+          matcher instanceof TestingLibraryDeserializedFunction
+            ? matcher.original
+            : matcher.toString(),
+          '\n',
+        ].join('\n'),
       )
+    }
 
-    // @ts-expect-error
-    const result = window.TestingLibraryDom[queryName](root, ...args)
+    return error
+  }
 
-    return result
-  },
-  queryAll(root, selector) {
-    const testingLibrary = window.TestingLibraryDom
-    const args = JSON.parse(selector, window.__testingLibraryReviver) as unknown as Parameters<
-      Queries[typeof queryName]
-    >
+  return {
+    query(root, selector) {
+      const args = JSON.parse(
+        selector,
+        window.__testingLibraryReviver,
+      ) as unknown as SynchronousQueryParameters
 
-    // @ts-expect-error
-    const result = testingLibrary[queryName](root, ...args)
+      if (isAllQuery(queryName))
+        throw new Error(
+          `PlaywrightTestingLibrary: the plural '${queryName}' was used to create this Locator`,
+        )
 
-    if (!result) return []
+      try {
+        // @ts-expect-error
+        const result = window.TestingLibraryDom[queryName](root, ...args)
 
-    return Array.isArray(result) ? result : [result]
-  },
-})
+        return result
+      } catch (error) {
+        throw getError(error, args[0])
+      }
+    },
+    queryAll(root, selector) {
+      const testingLibrary = window.TestingLibraryDom
+      const args = JSON.parse(
+        selector,
+        window.__testingLibraryReviver,
+      ) as unknown as SynchronousQueryParameters
+
+      try {
+        // @ts-expect-error
+        const result = testingLibrary[queryName](root, ...args)
+
+        if (!result) return []
+
+        return Array.isArray(result) ? result : [result]
+      } catch (error) {
+        throw getError(error, args[0])
+      }
+    },
+  }
+}
 
 const registerSelectorsFixture: [
   TestFixture<void, PlaywrightTestArgs>,

--- a/lib/fixture/locator/helpers.ts
+++ b/lib/fixture/locator/helpers.ts
@@ -1,7 +1,7 @@
 import {promises as fs} from 'fs'
 
 import {configureTestingLibraryScript} from '../../common'
-import {reviver} from '../helpers'
+import {TestingLibraryDeserializedFunction, reviver} from '../helpers'
 import type {Config, Selector, SynchronousQuery} from '../types'
 
 const queryToSelector = (query: SynchronousQuery) =>
@@ -17,8 +17,9 @@ const buildTestingLibraryScript = async ({config}: {config: Config}) => {
 
   return `
     ${configuredTestingLibraryDom}
-    
+
     window.__testingLibraryReviver = ${reviver.toString()};
+    ${TestingLibraryDeserializedFunction.toString()};
   `
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:legacy": "run-s build:testing-library test:standalone test:fixture:legacy",
     "test:fixture": "playwright test",
     "test:fixture:legacy": "playwright test test/fixture/element-handles.test.ts",
+    "test:fixture:locator": "playwright test test/fixture/locators.test.ts",
     "test:standalone": "hover-scripts test --no-watch",
     "test:types": "tsc --noEmit"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import {PlaywrightTestConfig} from '@playwright/test'
 const config: PlaywrightTestConfig = {
   reporter: 'list',
   testDir: 'test/fixture',
+  use: {actionTimeout: 3000},
 }
 
 export default config


### PR DESCRIPTION
Because we're (rudimentarily) serializing `TextMatch` functions, they can't reference outer closure scope.

#### Example

```ts
// ✅ This is supported
screen.getByText(content => content.startsWith('Foo'))

// ❌ This is not supported
const startsWithFoo = (content: string) => content.startsWith('Foo')

screen.getByText(content => startsWithFoo(content))
```

This adds a "known limitation" entry to the readme describing this limitation and attempts to detect `TextMatch` functions with external references in order to print a helpful error message.


<img width="904" alt="error" src="https://user-images.githubusercontent.com/288160/191911397-ca53e938-1a87-48dc-b391-4a16929a5dde.png">


